### PR TITLE
[PLA-1422] Remove scheduled command from CoreServiceProvider.

### DIFF
--- a/src/CoreServiceProvider.php
+++ b/src/CoreServiceProvider.php
@@ -19,7 +19,6 @@ use Enjin\Platform\Providers\Deferred\WebsocketClientProvider;
 use Enjin\Platform\Providers\FakerServiceProvider;
 use Enjin\Platform\Providers\GraphQlServiceProvider;
 use Enjin\Platform\Services\Processor\Substrate\BlockProcessor;
-use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
@@ -89,16 +88,6 @@ class CoreServiceProvider extends PackageServiceProvider
         $this->app->register(GraphQlServiceProvider::class);
         $this->app->register(FakerServiceProvider::class);
         $this->app->register(AuthServiceProvider::class);
-
-        $this->app->booted(function () {
-            $schedule = $this->app->make(Schedule::class);
-            $schedule->command('platform:transaction-checker')
-                ->everyFiveMinutes()
-                ->withoutOverlapping(3)
-                ->onOneServer()
-                ->runInBackground()
-                ->appendOutputTo(storage_path('logs/txchecker.log'));
-        });
 
         Event::listen(PlatformSyncing::class, fn () => BlockProcessor::synching());
         Event::listen(PlatformSynced::class, fn () => BlockProcessor::synchingDone());


### PR DESCRIPTION
To avoid unexpected issues it is recommended to run scheduled commands from within the app implementing this package, using the `schedule()` method in the `Kernel` class: https://laravel.com/docs/10.x/scheduling or via other similar means of running command on a cron.