### PR TITLE
[PLA-1579] Update validation rule

### DIFF
--- a/src/GraphQL/Schemas/Primary/Mutations/SetWalletAccountMutation.php
+++ b/src/GraphQL/Schemas/Primary/Mutations/SetWalletAccountMutation.php
@@ -50,7 +50,7 @@ class SetWalletAccountMutation extends Mutation implements PlatformGraphQlMutati
                 'type' => GraphQL::type('Int'),
                 'description' => __('enjin-platform::query.get_wallet.args.id'),
                 'rules' => [
-                    'prohibits:externalId',
+                    'required_without:externalId',
                     function (string $attribute, mixed $value, Closure $fail) {
                         if (!Wallet::where('id', $value)->exists()) {
                             $fail('validation.exists')->translate();
@@ -62,7 +62,7 @@ class SetWalletAccountMutation extends Mutation implements PlatformGraphQlMutati
                 'type' => GraphQL::type('String'),
                 'description' => __('enjin-platform::query.get_wallet.args.externalId'),
                 'rules' => [
-                    'prohibits:id',
+                    'required_without:id',
                     function (string $attribute, mixed $value, Closure $fail) {
                         if (!Wallet::where('external_id', $value)->exists()) {
                             $fail('validation.exists')->translate();

--- a/src/GraphQL/Schemas/Primary/Mutations/SetWalletAccountMutation.php
+++ b/src/GraphQL/Schemas/Primary/Mutations/SetWalletAccountMutation.php
@@ -51,6 +51,7 @@ class SetWalletAccountMutation extends Mutation implements PlatformGraphQlMutati
                 'description' => __('enjin-platform::query.get_wallet.args.id'),
                 'rules' => [
                     'required_without:externalId',
+                    'prohibits:externalId',
                     function (string $attribute, mixed $value, Closure $fail) {
                         if (!Wallet::where('id', $value)->exists()) {
                             $fail('validation.exists')->translate();
@@ -63,6 +64,7 @@ class SetWalletAccountMutation extends Mutation implements PlatformGraphQlMutati
                 'description' => __('enjin-platform::query.get_wallet.args.externalId'),
                 'rules' => [
                     'required_without:id',
+                    'prohibits:id',
                     function (string $attribute, mixed $value, Closure $fail) {
                         if (!Wallet::where('external_id', $value)->exists()) {
                             $fail('validation.exists')->translate();

--- a/tests/Feature/GraphQL/Mutations/SetWalletAccountTest.php
+++ b/tests/Feature/GraphQL/Mutations/SetWalletAccountTest.php
@@ -98,6 +98,19 @@ class SetWalletAccountTest extends TestCaseGraphQL
              ],
              $response['error']
          );
+
+         $response = $this->graphql($this->method, [
+             'id' => $wallet->id,
+             'externalId' => $wallet->external_id,
+             'account' => $wallet->public_key,
+         ], true);
+         $this->assertArraySubset(
+             [
+                 'id' => ['The id field prohibits external id from being present.'],
+                 'externalId' => ['The external id field prohibits id from being present.'],
+             ],
+             $response['error']
+         );
      }
 
     public function test_it_will_fail_with_no_address(): void

--- a/tests/Feature/GraphQL/Mutations/SetWalletAccountTest.php
+++ b/tests/Feature/GraphQL/Mutations/SetWalletAccountTest.php
@@ -84,6 +84,22 @@ class SetWalletAccountTest extends TestCaseGraphQL
 
     // Exception Path
 
+     public function test_it_will_fail_with_no_id_and_external_id(): void
+     {
+         $wallet = Wallet::factory()->create();
+         $response = $this->graphql($this->method, [
+             'account' => $wallet->public_key,
+         ], true);
+
+         $this->assertArraySubset(
+             [
+                 'id' => ['The id field is required when external id is not present.'],
+                 'externalId' => ['The external id field is required when id is not present.'],
+             ],
+             $response['error']
+         );
+     }
+
     public function test_it_will_fail_with_no_address(): void
     {
         $response = $this->graphql($this->method, [


### PR DESCRIPTION
## **Type**
bug_fix, tests


___

## **Description**
- Updated validation rules in `SetWalletAccountMutation.php` to require `id` when `externalId` is missing and vice versa.
- Added a new test case `test_it_will_fail_with_no_id_and_external_id` in `SetWalletAccountTest.php` to verify the updated validation logic.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SetWalletAccountMutation.php</strong><dd><code>Update Validation Rules for Wallet Account Mutation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Mutations/SetWalletAccountMutation.php
<li>Changed validation rule from <code>prohibits:externalId</code> to <br><code>required_without:externalId</code> for <code>id</code> field.<br> <li> Changed validation rule from <code>prohibits:id</code> to <code>required_without:id</code> for <br><code>externalId</code> field.


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/131/files#diff-b054f8bc8d2a14bdf8d05e462b14dc9ca8a75bf3f4900cabd786eeb69a2753d1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SetWalletAccountTest.php</strong><dd><code>Add Test for Updated Validation Rules in Wallet Account Mutation</code></dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/SetWalletAccountTest.php
<li>Added a new test <code>test_it_will_fail_with_no_id_and_external_id</code> to <br>ensure failure when both <code>id</code> and <code>externalId</code> are missing.


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/131/files#diff-501bc6f4578bde7ab9c6c5ac4f301e19049d1d777d4f3a2f4154546d6a0cafb5">+16/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
