### PR TITLE
[PLA-1601] Return error when null auth driver is used in production.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
   },
   "require-dev": {
     "dms/phpunit-arraysubset-asserts": "dev-master",
-    "friendsofphp/php-cs-fixer": "^3.0",
+    "friendsofphp/php-cs-fixer": "^v3.48",
     "nunomaduro/collision": "^7.0",
     "nunomaduro/larastan": "^2.0",
     "orchestra/testbench": "^8.0",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
   },
   "require-dev": {
     "dms/phpunit-arraysubset-asserts": "dev-master",
-    "friendsofphp/php-cs-fixer": "^v3.48",
+    "friendsofphp/php-cs-fixer": "^3.0",
     "nunomaduro/collision": "^7.0",
     "nunomaduro/larastan": "^2.0",
     "orchestra/testbench": "^8.0",

--- a/config/enjin-platform.php
+++ b/config/enjin-platform.php
@@ -189,7 +189,7 @@ return [
     |
     */
     'qr' => [
-        'adapter' => \Enjin\Platform\Services\Qr\Adapters\PlatformQrAdapter::class,
+        'adapter' => Enjin\Platform\Services\Qr\Adapters\PlatformQrAdapter::class,
         'size' => env('QR_CODE_SIZE', 512),
         'format' => env('QR_CODE_FORMAT', 'png'),
     ],

--- a/config/graphql.php
+++ b/config/graphql.php
@@ -9,13 +9,13 @@ return [
 
         // The controller/method to use in GraphQL request.
         // Also supported array syntax: `[\Rebing\GraphQL\GraphQLController::class, 'query']`
-        'controller' => \Enjin\Platform\Http\Controllers\GraphQLController::class . '@query',
+        'controller' => Enjin\Platform\Http\Controllers\GraphQLController::class . '@query',
 
         // Any middleware for the graphql route group
         // This middleware will apply to all schemas
         'middleware' => [
-            \Illuminate\Session\Middleware\StartSession::class,
-            \Enjin\Platform\Middlewares\Authenticated::class,
+            Illuminate\Session\Middleware\StartSession::class,
+            Enjin\Platform\Middlewares\Authenticated::class,
         ],
 
         // Additional route group attributes
@@ -111,7 +111,7 @@ return [
     'types' => [
         // ExampleType::class,
         // ExampleRelationType::class,
-        \Rebing\GraphQL\Support\UploadType::class,
+        Rebing\GraphQL\Support\UploadType::class,
     ],
 
     // This callable will be passed the Error object for each errors GraphQL catch.
@@ -121,7 +121,7 @@ return [
     //     'message' => '',
     //     'locations' => []
     // ]
-    'error_formatter' => [\Rebing\GraphQL\GraphQL::class, 'formatError'],
+    'error_formatter' => [Rebing\GraphQL\GraphQL::class, 'formatError'],
 
     /*
      * Custom Error Handling
@@ -130,7 +130,7 @@ return [
      *
      * The default handler will pass exceptions to laravel Error Handling mechanism
      */
-    'errors_handler' => [\Rebing\GraphQL\GraphQL::class, 'handleErrors'],
+    'errors_handler' => [Rebing\GraphQL\GraphQL::class, 'handleErrors'],
 
     /*
      * Options to limit the query complexity and depth. See the doc
@@ -147,13 +147,13 @@ return [
      * You can define your own pagination type.
      * Reference \Rebing\GraphQL\Support\PaginationType::class
      */
-    'pagination_type' => \Enjin\Platform\GraphQL\Types\Pagination\ConnectionType::class,
+    'pagination_type' => Enjin\Platform\GraphQL\Types\Pagination\ConnectionType::class,
 
     /*
      * You can define your own simple pagination type.
      * Reference \Rebing\GraphQL\Support\SimplePaginationType::class
      */
-    'simple_pagination_type' => \Rebing\GraphQL\Support\SimplePaginationType::class,
+    'simple_pagination_type' => Rebing\GraphQL\Support\SimplePaginationType::class,
 
     /*
      * Overrides the default field resolver
@@ -211,12 +211,12 @@ return [
      * Execution middlewares
      */
     'execution_middleware' => [
-        \Rebing\GraphQL\Support\ExecutionMiddleware\ValidateOperationParamsMiddleware::class,
-        \Enjin\Platform\Middlewares\OperationDefinitionNodeStore::class,
+        Rebing\GraphQL\Support\ExecutionMiddleware\ValidateOperationParamsMiddleware::class,
+        Enjin\Platform\Middlewares\OperationDefinitionNodeStore::class,
         // AutomaticPersistedQueriesMiddleware listed even if APQ is disabled, see the docs for the `'apq'` configuration
-        \Rebing\GraphQL\Support\ExecutionMiddleware\AutomaticPersistedQueriesMiddleware::class,
-        \Rebing\GraphQL\Support\ExecutionMiddleware\AddAuthUserContextValueMiddleware::class,
+        Rebing\GraphQL\Support\ExecutionMiddleware\AutomaticPersistedQueriesMiddleware::class,
+        Rebing\GraphQL\Support\ExecutionMiddleware\AddAuthUserContextValueMiddleware::class,
         // \Rebing\GraphQL\Support\ExecutionMiddleware\UnusedVariablesMiddleware::class,
-        \Enjin\Platform\Middlewares\UniqueFieldNamesArray::class,
+        Enjin\Platform\Middlewares\UniqueFieldNamesArray::class,
     ],
 ];

--- a/lang/en/error.php
+++ b/lang/en/error.php
@@ -5,6 +5,7 @@ return [
     'auth.auth_not_defined' => 'The auth is not defined.',
     'auth.basic_token.token_not_defined' => 'The basic token is not defined in your .env',
     'auth.driver_not_supported' => 'Driver [:driver] is not supported.',
+    'auth.null_driver_not_allowed_in_production' => 'The Null auth driver cannot be used in production.',
     'cannot_represent_integer_range' => 'Cannot represent following value as integer range: :value',
     'cannot_represent_integer_ranges_array' => 'Cannot represent following value as integer ranges array: :value',
     'cannot_represent_object' => 'Cannot represent following value as object: ',

--- a/src/Http/Controllers/QrController.php
+++ b/src/Http/Controllers/QrController.php
@@ -27,7 +27,7 @@ class QrController extends Controller
             throw new PlatformException(__('enjin-platform::error.qr.extension_not_installed'), 501);
         }
 
-        $qrCode = QRCode::format($format)->size($size)->generate($data);
+        $qrCode = QrCode::format($format)->size($size)->generate($data);
         $mimeType = match ($format) {
             'eps' => 'application/postscript',
             'svg' => 'image/svg+xml',

--- a/src/Services/Auth/Drivers/NullAuth.php
+++ b/src/Services/Auth/Drivers/NullAuth.php
@@ -4,6 +4,7 @@ namespace Enjin\Platform\Services\Auth\Drivers;
 
 use Enjin\Platform\Services\Auth\Authenticator;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 class NullAuth implements Authenticator
 {
@@ -12,7 +13,7 @@ class NullAuth implements Authenticator
      */
     public function authenticate(Request $request): bool
     {
-        return true;
+        return !$this->isProduction();
     }
 
     /**
@@ -25,11 +26,16 @@ class NullAuth implements Authenticator
 
     public function getError(): string
     {
-        return '';
+        return $this->isProduction() ? __('enjin-platform::error.auth.null_driver_not_allowed_in_production') : '';
     }
 
     public static function create(): Authenticator
     {
         return new static();
+    }
+
+    private function isProduction()
+    {
+        return 'production' === Str::lower(config('app.env'));
     }
 }

--- a/tests/Feature/GraphQL/Mutations/RemoveAllAttributesTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveAllAttributesTest.php
@@ -36,7 +36,7 @@ class RemoveAllAttributesTest extends TestCaseGraphQL
     protected Model $token;
     protected Encoder $tokenIdEncoder;
     protected Model $attribute;
-    protected MOdel $wallet;
+    protected Model $wallet;
 
     protected function setUp(): void
     {

--- a/tests/Feature/GraphQL/Mutations/SetWalletAccountTest.php
+++ b/tests/Feature/GraphQL/Mutations/SetWalletAccountTest.php
@@ -84,34 +84,34 @@ class SetWalletAccountTest extends TestCaseGraphQL
 
     // Exception Path
 
-     public function test_it_will_fail_with_no_id_and_external_id(): void
-     {
-         $wallet = Wallet::factory()->create();
-         $response = $this->graphql($this->method, [
-             'account' => $wallet->public_key,
-         ], true);
+    public function test_it_will_fail_with_no_id_and_external_id(): void
+    {
+        $wallet = Wallet::factory()->create();
+        $response = $this->graphql($this->method, [
+            'account' => $wallet->public_key,
+        ], true);
 
-         $this->assertArraySubset(
-             [
-                 'id' => ['The id field is required when external id is not present.'],
-                 'externalId' => ['The external id field is required when id is not present.'],
-             ],
-             $response['error']
-         );
+        $this->assertArraySubset(
+            [
+                'id' => ['The id field is required when external id is not present.'],
+                'externalId' => ['The external id field is required when id is not present.'],
+            ],
+            $response['error']
+        );
 
-         $response = $this->graphql($this->method, [
-             'id' => $wallet->id,
-             'externalId' => $wallet->external_id,
-             'account' => $wallet->public_key,
-         ], true);
-         $this->assertArraySubset(
-             [
-                 'id' => ['The id field prohibits external id from being present.'],
-                 'externalId' => ['The external id field prohibits id from being present.'],
-             ],
-             $response['error']
-         );
-     }
+        $response = $this->graphql($this->method, [
+            'id' => $wallet->id,
+            'externalId' => $wallet->external_id,
+            'account' => $wallet->public_key,
+        ], true);
+        $this->assertArraySubset(
+            [
+                'id' => ['The id field prohibits external id from being present.'],
+                'externalId' => ['The external id field prohibits id from being present.'],
+            ],
+            $response['error']
+        );
+    }
 
     public function test_it_will_fail_with_no_address(): void
     {

--- a/tests/Unit/AuthServiceTest.php
+++ b/tests/Unit/AuthServiceTest.php
@@ -35,4 +35,14 @@ class AuthServiceTest extends TestCase
         $this->assertEmpty($auth->getError());
         $this->assertTrue($auth->authenticate(request()));
     }
+
+    public function test_it_returns_error_with_null_auth_in_production()
+    {
+        $this->app['config']->set('app.env', 'production');
+        $auth = resolve(AuthManager::class)->driver();
+        $this->assertInstanceOf(NullAuth::class, $auth);
+        $this->assertEmpty($auth->getToken());
+        $this->assertSame(__('enjin-platform::error.auth.null_driver_not_allowed_in_production'), $auth->getError());
+        $this->assertFalse($auth->authenticate(request()));
+    }
 }


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Added a new error message for using the Null auth driver in production environments and implemented a check to prevent its usage.
- Updated class references across configuration files to use unqualified names, simplifying the configuration.
- Fixed a case sensitivity issue in `QrController` by correcting the case of the `QrCode` class instantiation.
- Added a unit test to verify the behavior of NullAuth in production environments.
- Updated the version of `friendsofphp/php-cs-fixer` in `composer.json`.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>enjin-platform.php</strong><dd><code>Simplify class references in configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/enjin-platform.php
<li>Updated class references to use unqualified names instead of fully <br>qualified names.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/133/files#diff-e687a9c8af991f77587526ea6983e8c280929f8ccf6b989eb1eb83c0d8f4d220">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>graphql.php</strong><dd><code>Update GraphQL configuration with simplified class references</code></dd></summary>
<hr>

config/graphql.php
<li>Updated various class references to use unqualified names.<br> <li> Adjusted middleware and types configuration with simplified class <br>names.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/133/files#diff-3df7a66039dfe7fcbffc8e326bb54aa613522ab5589fec67c417bc59771257a0">+13/-13</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>error.php</strong><dd><code>Add error message for Null auth driver in production</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lang/en/error.php
<li>Added a new error message for using the Null auth driver in <br>production.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/133/files#diff-9d2a0f05bd014e65c2a160750b61a215279383a4440983a05e8cfe8757f29374">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>NullAuth.php</strong><dd><code>Prevent NullAuth usage in production environments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Auth/Drivers/NullAuth.php
<li>Added a check to prevent using NullAuth in production.<br> <li> Included an error message for attempts to use NullAuth in production.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/133/files#diff-82240a1e60b0f9e61fb09bda210c8c45103f39a8c54ac0bfaf49e07dffcecaf7">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Bug_fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>QrController.php</strong><dd><code>Fix QrCode class case sensitivity in QrController</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Http/Controllers/QrController.php
<li>Fixed case sensitivity issue with the <code>QrCode</code> class instantiation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/133/files#diff-a78337e0d2c1fbdda72faad8543eccd86a2880abe32434f6885ae786a4506c65">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RemoveAllAttributesTest.php</strong><dd><code>Fix typo in RemoveAllAttributesTest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/RemoveAllAttributesTest.php
- Corrected a typo in variable declaration.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/133/files#diff-e13778f18e9aeddfdbb9cd5a2e0680f422086bd34b56b25d528269ebf9e45920">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>SetWalletAccountTest.php</strong><dd><code>Code formatting in SetWalletAccountTest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/SetWalletAccountTest.php
- Reformatted code for clarity without changing functionality.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/133/files#diff-501bc6f4578bde7ab9c6c5ac4f301e19049d1d777d4f3a2f4154546d6a0cafb5">+28/-28</a>&nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>AuthServiceTest.php</strong><dd><code>Add test for NullAuth in production environment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/AuthServiceTest.php
- Added a test to verify NullAuth behavior in production.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/133/files#diff-7ba353998f55ebbf1c1c0b966ae4a70e033e94b430a505951d788fc8f566e284">+10/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>composer.json</strong><dd><code>Update php-cs-fixer version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

composer.json
- Updated the version of `friendsofphp/php-cs-fixer`.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/133/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
