### PR TITLE
[PLA-1590] Add support for batch transactions with continueOnFailure.

### DIFF
--- a/tests/Unit/EncodingTest.php
+++ b/tests/Unit/EncodingTest.php
@@ -1214,7 +1214,7 @@ class EncodingTest extends TestCase
         );
     }
 
-    public function test_it_can_encode_efinity_utility_batch()
+    public function test_it_can_encode_matrix_utility_batch()
     {
         $call = TransactionSerializer::encode('Mint', CreateTokenMutation::getEncodableParams(
             recipientAccount: '0x52e3c0eb993523286d19954c7e3ada6f791fa3f32764e44b9c1df0c2723bc15e',
@@ -1237,6 +1237,33 @@ class EncodingTest extends TestCase
         $callIndex = $this->codec->encoder()->getCallIndex('MatrixUtility.batch', true);
         $this->assertEquals(
             "0x{$callIndex}0828040052e3c0eb993523286d19954c7e3ada6f791fa3f32764e44b9c1df0c2723bc15e0400fd03b67a0300000100a0724e18090000000000000000000000000000000028040052e3c0eb993523286d19954c7e3ada6f791fa3f32764e44b9c1df0c2723bc15e0400fd03b67a0300000100a0724e18090000000000000000000000000000000000",
+            $data
+        );
+    }
+
+    public function test_it_can_encode_matrix_utility_batch_with_continue_on_failure()
+    {
+        $call = TransactionSerializer::encode('Mint', CreateTokenMutation::getEncodableParams(
+            recipientAccount: '0x52e3c0eb993523286d19954c7e3ada6f791fa3f32764e44b9c1df0c2723bc15e',
+            collectionId: '1',
+            createTokenParams: new CreateTokenParams(
+                tokenId: '255',
+                initialSupply: '57005',
+                cap: TokenMintCapType::INFINITE,
+                unitPrice: '10000000000000',
+                behavior: null,
+                listingForbidden: null
+            )
+        ));
+
+        $data = $this->codec->encoder()->batch(
+            calls: [$call, $call],
+            continueOnFailure: true,
+        );
+
+        $callIndex = $this->codec->encoder()->getCallIndex('MatrixUtility.batch', true);
+        $this->assertEquals(
+            "0x{$callIndex}0828040052e3c0eb993523286d19954c7e3ada6f791fa3f32764e44b9c1df0c2723bc15e0400fd03b67a0300000100a0724e18090000000000000000000000000000000028040052e3c0eb993523286d19954c7e3ada6f791fa3f32764e44b9c1df0c2723bc15e0400fd03b67a0300000100a0724e18090000000000000000000000000000000001",
             $data
         );
     }


### PR DESCRIPTION
## **Type**
enhancement, tests


___

## **Description**
- Added support for `continueOnFailure` in both batch mint and batch transfer mutations, allowing transactions to continue even if some fail.
- Introduced new test cases to verify the functionality of `continueOnFailure` for both batch minting and transferring.
- Updated and added encoding tests to ensure proper handling of utility batches, including scenarios with `continueOnFailure`.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BatchMintMutation.php</strong><dd><code>Add continueOnFailure Support to Batch Mint Mutation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Substrate/Mutations/BatchMintMutation.php
<li>Added <code>continueOnFailure</code> argument to batch mint mutation with a default <br>value of false.<br> <li> Updated logic to use <code>continueOnFailure</code> argument value in the mutation <br>process.<br> <li> Changed recipient mapping to use Laravel's <code>collect</code> helper for <br>consistency.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/136/files#diff-3316a6892fe09365b961b443e48d3d05fe572745e995d57d4ac36d1c0c5469fd">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BatchTransferMutation.php</strong><dd><code>Implement continueOnFailure in Batch Transfer Mutation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Substrate/Mutations/BatchTransferMutation.php
<li>Introduced <code>continueOnFailure</code> argument to batch transfer mutation with <br>a default value of false.<br> <li> Modified to utilize <code>continueOnFailure</code> argument value during the <br>mutation execution.<br> <li> Adjusted recipient mapping to employ Laravel's <code>collect</code> method for <br>uniformity.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/136/files#diff-6072f9f927ff950a4a5e38fdf30790c51191d00b853632ed08bc0beeade9a70e">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BatchMintTest.php</strong><dd><code>Test Batch Minting with continueOnFailure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/BatchMintTest.php
<li>Added a test case for batch minting multiple tokens with <br><code>continueOnFailure</code> enabled.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/136/files#diff-2cbe3b0c438ada05234d4d75c4c00ae56a587cabb9b3f44ffe06bbf26713b73e">+53/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BatchTransferTest.php</strong><dd><code>Test Batch Transfer with continueOnFailure Enabled</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/BatchTransferTest.php
<li>Created a test for batch transferring with <code>continueOnFailure</code> set to <br>true.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/136/files#diff-125eb5f695a57972cc8ac00273aee5bfc7cfd9a264584ce991fe6a4ce626c0c5">+54/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>EncodingTest.php</strong><dd><code>Update and Add Encoding Tests for Utility Batch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/EncodingTest.php
<li>Updated a test name to reflect the utility batch encoding accurately.<br> <li> Added a new test for encoding utility batch with <code>continueOnFailure</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/136/files#diff-304632780535cba1fc76d5ae4d6cfca20af64a2f1fb2e4a782300d6035017d2e">+28/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

