### PR TITLE
Add mass pruneable blocks

### DIFF
--- a/config/enjin-platform.php
+++ b/config/enjin-platform.php
@@ -228,4 +228,15 @@ return [
         'api_url' => env('GITHUB_API_URL', 'https://api.github.com/'),
         'token' => env('GITHUB_TOKEN'),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Prune blocks
+    |--------------------------------------------------------------------------
+    |
+    | Here, you can specify the number of days to retain blocks data before pruning.
+    | If set to null or zero, blocks will not be pruned.
+    |
+    */
+    'prune_blocks' => env('PRUNE_BLOCKS', 7),
 ];

--- a/database/factories/BlockFactory.php
+++ b/database/factories/BlockFactory.php
@@ -22,7 +22,7 @@ class BlockFactory extends Factory
     public function definition()
     {
         return [
-            'number' => $this->faker->numberBetween(1),
+            'number' => $this->faker->numberBetween(1, 1000000),
             'hash' => $this->faker->unique()->public_key(),
         ];
     }

--- a/database/factories/BlockFactory.php
+++ b/database/factories/BlockFactory.php
@@ -22,7 +22,7 @@ class BlockFactory extends Factory
     public function definition()
     {
         return [
-            'number' => random_int(1, 1000),
+            'number' => $this->faker->numberBetween(1),
             'hash' => $this->faker->unique()->public_key(),
         ];
     }

--- a/src/Models/Laravel/Block.php
+++ b/src/Models/Laravel/Block.php
@@ -48,7 +48,7 @@ class Block extends BaseModel
      */
     public function prunable(): Builder
     {
-        if (!is_null($days = config('enjin-platform.prune_blocks'))) {
+        if (filled($days = config('enjin-platform.prune_blocks'))) {
             return static::where('created_at', '<=', now()->subDays($days));
         }
 

--- a/src/Models/Laravel/Block.php
+++ b/src/Models/Laravel/Block.php
@@ -52,7 +52,7 @@ class Block extends BaseModel
             return static::where('created_at', '<=', now()->subDays($days));
         }
 
-        return static::where('id', 0);
+        return static::query();
     }
 
     /**

--- a/src/Models/Laravel/Block.php
+++ b/src/Models/Laravel/Block.php
@@ -5,12 +5,15 @@ namespace Enjin\Platform\Models\Laravel;
 use Enjin\Platform\Database\Factories\BlockFactory;
 use Enjin\Platform\Models\BaseModel;
 use Enjin\Platform\Models\Laravel\Traits\EagerLoadSelectFields;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\MassPrunable;
 
 class Block extends BaseModel
 {
     use HasFactory;
     use EagerLoadSelectFields;
+    use MassPrunable;
 
 
     /**
@@ -37,6 +40,20 @@ class Block extends BaseModel
         'created_at',
         'updated_at',
     ];
+
+    /**
+     * Get the prunable model query.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function prunable(): Builder
+    {
+        if (!is_null($days = config('enjin-platform.prune_blocks'))) {
+            return static::where('created_at', '<=', now()->subDays($days));
+        }
+
+        return static::where('id', 0);
+    }
 
     /**
      * Create a new factory instance for the model.

--- a/src/Models/Laravel/Block.php
+++ b/src/Models/Laravel/Block.php
@@ -48,7 +48,7 @@ class Block extends BaseModel
      */
     public function prunable(): Builder
     {
-        if (filled($days = config('enjin-platform.prune_blocks'))) {
+        if (!empty($days = config('enjin-platform.prune_blocks'))) {
             return static::where('created_at', '<=', now()->subDays($days));
         }
 

--- a/src/Models/Laravel/Block.php
+++ b/src/Models/Laravel/Block.php
@@ -52,7 +52,7 @@ class Block extends BaseModel
             return static::where('created_at', '<=', now()->subDays($days));
         }
 
-        return static::query();
+        return static::where('id', 0);
     }
 
     /**

--- a/tests/Feature/Commands/PruneTest.php
+++ b/tests/Feature/Commands/PruneTest.php
@@ -56,7 +56,7 @@ class PruneTest extends TestCaseGraphQL
         $this->artisan('model:prune', ['--model' => Block::resolveClassFqn()]);
         $this->assertNotEmpty(Block::count());
 
-        config(['enjin-platform.prune_expired_events' => 0]);
+        config(['enjin-platform.prune_blocks' => 0]);
         $this->artisan('model:prune', ['--model' => Block::resolveClassFqn()]);
         $this->assertNotEmpty(Block::count());
     }

--- a/tests/Feature/Commands/PruneTest.php
+++ b/tests/Feature/Commands/PruneTest.php
@@ -39,7 +39,7 @@ class PruneTest extends TestCaseGraphQL
     public function test_it_can_prune_expired_blocks(): void
     {
         Block::truncate();
-        Block::factory(fake()->numberBetween(1,100))->create([
+        Block::factory(fake()->numberBetween(1, 100))->create([
             'created_at' => now()->subDays(config('enjin-platform.prune_blocks') + 1)->toDateTimeString(),
         ]);
         $this->artisan('model:prune', ['--model' => Block::resolveClassFqn()]);
@@ -50,7 +50,7 @@ class PruneTest extends TestCaseGraphQL
     {
         config(['enjin-platform.prune_blocks' => null]);
         Block::truncate();
-        Block::factory(fake()->numberBetween(1,100))->create([
+        Block::factory(fake()->numberBetween(1, 100))->create([
             'created_at' => now()->subDays(config('enjin-platform.prune_blocks') + 1)->toDateTimeString(),
         ]);
         $this->artisan('model:prune', ['--model' => Block::resolveClassFqn()]);

--- a/tests/Feature/Commands/PruneTest.php
+++ b/tests/Feature/Commands/PruneTest.php
@@ -2,6 +2,7 @@
 
 namespace Enjin\Platform\Tests\Feature\Commands;
 
+use Enjin\Platform\Models\Block;
 use Enjin\Platform\Models\PendingEvent;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
 
@@ -33,5 +34,30 @@ class PruneTest extends TestCaseGraphQL
         config(['enjin-platform.prune_expired_events' => 0]);
         $this->artisan('model:prune', ['--model' => PendingEvent::resolveClassFqn()]);
         $this->assertNotEmpty(PendingEvent::count());
+    }
+
+    public function test_it_can_prune_expired_blocks(): void
+    {
+        Block::truncate();
+        Block::factory(fake()->numberBetween(1,100))->create([
+            'created_at' => now()->subDays(config('enjin-platform.prune_blocks') + 1)->toDateTimeString(),
+        ]);
+        $this->artisan('model:prune', ['--model' => Block::resolveClassFqn()]);
+        $this->assertDatabaseCount('blocks', 0);
+    }
+
+    public function test_it_cannot_prune_expired_blocks(): void
+    {
+        config(['enjin-platform.prune_blocks' => null]);
+        Block::truncate();
+        Block::factory(fake()->numberBetween(1,100))->create([
+            'created_at' => now()->subDays(config('enjin-platform.prune_blocks') + 1)->toDateTimeString(),
+        ]);
+        $this->artisan('model:prune', ['--model' => Block::resolveClassFqn()]);
+        $this->assertNotEmpty(Block::count());
+
+        config(['enjin-platform.prune_expired_events' => 0]);
+        $this->artisan('model:prune', ['--model' => Block::resolveClassFqn()]);
+        $this->assertNotEmpty(Block::count());
     }
 }


### PR DESCRIPTION
## **Type**
enhancement, tests


___

## **Description**
- Added a new configuration option `prune_blocks` to specify the number of days to retain block data before pruning.
- Updated the Block model to support mass pruning based on the new configuration.
- Updated the BlockFactory to use a more flexible number generation for block numbers.
- Added tests to verify the functionality of pruning blocks based on the new configuration.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>enjin-platform.php</strong><dd><code>Add Configuration for Pruning Blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/enjin-platform.php
- Added configuration for pruning blocks with a default of 7 days.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/137/files#diff-e687a9c8af991f77587526ea6983e8c280929f8ccf6b989eb1eb83c0d8f4d220">+11/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BlockFactory.php</strong><dd><code>Update Block Number Generation in Factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

database/factories/BlockFactory.php
<li>Updated block number generation to use Faker's numberBetween method <br>without specifying the upper limit.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/137/files#diff-6022d0ecb6a8f4f531cc7df0490139192f508dc3d08a49fbbcd19174438513e2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Block.php</strong><dd><code>Implement MassPrunable in Block Model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Models/Laravel/Block.php
<li>Imported MassPrunable and Builder.<br> <li> Implemented MassPrunable with a prunable method to define the pruning <br>logic based on the configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/137/files#diff-abfa5a67f0c0662601ff13ee112f40ff296ba05cf8a106ec2164997f004af68d">+17/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PruneTest.php</strong><dd><code>Add Tests for Pruning Expired Blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/Commands/PruneTest.php
<li>Added tests for pruning expired blocks.<br> <li> Ensured blocks are not pruned when configured not to.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/137/files#diff-75d28d1bf3360ab03baf3f9da7e88a6d59a084fd3d9b475dac8e9f06fac23d0e">+26/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

