### PR TITLE
[PLA-1608] Token metadata fallback, and {id} replacement.

### DIFF
--- a/src/GraphQL/Types/Substrate/AttributeType.php
+++ b/src/GraphQL/Types/Substrate/AttributeType.php
@@ -5,6 +5,7 @@ namespace Enjin\Platform\GraphQL\Types\Substrate;
 use Enjin\Platform\GraphQL\Types\Traits\InSubstrateSchema;
 use Enjin\Platform\Interfaces\PlatformGraphQlType;
 use Enjin\Platform\Models\Attribute;
+use Illuminate\Support\Str;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Support\Type;
 
@@ -40,7 +41,7 @@ class AttributeType extends Type implements PlatformGraphQlType
                 'description' => __('enjin-platform::mutation.batch_set_attribute.args.value'),
                 'resolve' => function ($attribute) {
                     if (strtolower($attribute->key) == 'uri' && strpos($attribute->value, '{id}') !== false && $attribute->token_id) {
-                        return str_replace('{id}', "{$attribute->token->collection->collection_chain_id}-{$attribute->token->token_chain_id}", $attribute->value);
+                        return Str::replace('{id}', "{$attribute->token->collection->collection_chain_id}-{$attribute->token->token_chain_id}", $attribute->value);
                     }
 
                     return $attribute->value;

--- a/src/GraphQL/Types/Substrate/AttributeType.php
+++ b/src/GraphQL/Types/Substrate/AttributeType.php
@@ -40,7 +40,7 @@ class AttributeType extends Type implements PlatformGraphQlType
                 'description' => __('enjin-platform::mutation.batch_set_attribute.args.value'),
                 'resolve' => function ($attribute) {
                     if (strtolower($attribute->key) == 'uri' && strpos($attribute->value, '{id}') !== false && $attribute->token_id) {
-                        return str_replace('{id}', $attribute->token->token_chain_id, $attribute->value);
+                        return str_replace('{id}', "{$attribute->token->collection->collection_chain_id}-{$attribute->token->token_chain_id}", $attribute->value);
                     }
 
                     return $attribute->value;

--- a/src/Models/Laravel/Block.php
+++ b/src/Models/Laravel/Block.php
@@ -44,7 +44,7 @@ class Block extends BaseModel
     /**
      * Get the prunable model query.
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     public function prunable(): Builder
     {

--- a/src/Models/Laravel/Token.php
+++ b/src/Models/Laravel/Token.php
@@ -11,6 +11,7 @@ use Enjin\Platform\Models\Laravel\Traits\Token as TokenMethods;
 use Facades\Enjin\Platform\Services\Database\MetadataService;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Str;
 use Staudenmeir\EloquentEagerLimit\HasEagerLimit;
 
 class Token extends BaseModel
@@ -140,7 +141,25 @@ class Token extends BaseModel
     protected function metadata(): Attribute
     {
         return new Attribute(
-            get: fn () => $this->attributes['metadata'] ?? MetadataService::fetch($this->getRelation('attributes')->first()),
+            get: function () {
+                $tokenUriAttribute = $this->load('attributes')->getRelation('attributes')
+                    ->filter(fn ($attribute) => 'uri' == $attribute->key)
+                    ->first();
+
+                $metadata = $this->attributes['metadata'] ?? MetadataService::fetch($tokenUriAttribute);
+                if (!$metadata) {
+                    $collectionUriAttribute = $this->collection->load('attributes')->getRelation('attributes')
+                        ->filter(fn ($attribute) => 'uri' == $attribute->key)
+                        ->first();
+                    if ($collectionUriAttribute && Str::contains($collectionUriAttribute, '{id}')) {
+                        $collectionUriAttribute->value = Str::replace('{id}', "{$this->collection->collection_chain_id}-{$this->token_chain_id}", $collectionUriAttribute->value);
+                    }
+
+                    $metadata = MetadataService::fetch($collectionUriAttribute);
+                }
+
+                return $metadata;
+            },
         );
     }
 

--- a/src/Models/Laravel/Token.php
+++ b/src/Models/Laravel/Token.php
@@ -151,7 +151,7 @@ class Token extends BaseModel
                     $collectionUriAttribute = $this->collection->load('attributes')->getRelation('attributes')
                         ->filter(fn ($attribute) => 'uri' == $attribute->key)
                         ->first();
-                    if ($collectionUriAttribute && Str::contains($collectionUriAttribute, '{id}')) {
+                    if ($collectionUriAttribute && Str::contains($collectionUriAttribute->value, '{id}')) {
                         $collectionUriAttribute->value = Str::replace('{id}', "{$this->collection->collection_chain_id}-{$this->token_chain_id}", $collectionUriAttribute->value);
                     }
 

--- a/tests/Feature/GraphQL/Queries/GetTokenTest.php
+++ b/tests/Feature/GraphQL/Queries/GetTokenTest.php
@@ -83,7 +83,7 @@ class GetTokenTest extends TestCaseGraphQL
         $this->assertArraySubset([
             'attributes' => [[
                 'key' => 'uri',
-                'value' => 'https://example.com/' . $this->token->token_chain_id,
+                'value' => "https://example.com/{$this->collection->collection_chain_id}-{$this->token->token_chain_id}",
             ],
             ],
         ], $response);


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Enhanced URI attribute resolution in `AttributeType.php` to include both `collection_chain_id` and `token_chain_id`.
- Updated documentation for the return type of the prunable method in `Block.php`.
- Introduced a new mechanism in `Token.php` for fetching metadata using the collection's URI attribute as a fallback when token's metadata is not directly available.
- Updated `GetTokenTest.php` to assert the new format of URI values that include both collection and token chain IDs.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AttributeType.php</strong><dd><code>Enhanced URI Attribute Resolution with Collection ID Support</code></dd></summary>
<hr>

src/GraphQL/Types/Substrate/AttributeType.php
<li>Enhanced URI attribute resolution to include collection_chain_id along <br>with token_chain_id.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/138/files#diff-1a4d2d8275bef6cfac8ab8d7359c72865462c4e5c9355cf96157cb84c24d374e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Token.php</strong><dd><code>Enhanced Metadata Fetching with Collection URI Fallback</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/Models/Laravel/Token.php
<li>Added support for fetching metadata using collection's URI attribute <br>when token's metadata is not available.<br> <li> Introduced a fallback mechanism to use collection's URI attribute for <br>metadata fetching.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/138/files#diff-c43aa5a65eba10e52488cbe7124d7bfed85857e528af165379a505edd28c5597">+20/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Block.php</strong><dd><code>Documentation Update for Prunable Method Return Type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Models/Laravel/Block.php
- Updated the return type documentation for the prunable method.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/138/files#diff-abfa5a67f0c0662601ff13ee112f40ff296ba05cf8a106ec2164997f004af68d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GetTokenTest.php</strong><dd><code>Test Update for New URI Value Format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Queries/GetTokenTest.php
<li>Updated test to assert the new URI value format including <br>collection_chain_id and token_chain_id.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/138/files#diff-48e75f21d6a8e154b2223b57c0c9e983c9541eac8294bd5b188698adfba3a30b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

