### PR TITLE
[PLA-1681] Bump transactionVersion and specVersion

### DIFF
--- a/config/enjin-platform.php
+++ b/config/enjin-platform.php
@@ -98,8 +98,8 @@ return [
                     'node' => env('SUBSTRATE_ENJIN_RPC', 'wss://rpc.matrix.blockchain.enjin.io'),
                     'ss58-prefix' => env('SUBSTRATE_ENJIN_SS58_PREFIX', 1110),
                     'genesis-hash' => env('SUBSTRATE_ENJIN_GENESIS_HASH', '0x3af4ff48ec76d2efc8476730f423ac07e25ad48f5f4c9dc39c778b164d808615'),
-                    'spec-version' => env('SUBSTRATE_ENJIN_SPEC_VERSION', 1003),
-                    'transaction-version' => env('SUBSTRATE_ENJIN_TRANSACTION_VERSION', 5),
+                    'spec-version' => env('SUBSTRATE_ENJIN_SPEC_VERSION', 1005),
+                    'transaction-version' => env('SUBSTRATE_ENJIN_TRANSACTION_VERSION', 7),
                 ],
                 'canary' => [
                     'chain-id' => 0,
@@ -109,8 +109,8 @@ return [
                     'node' => env('SUBSTRATE_CANARY_RPC', 'wss://rpc.matrix.canary.enjin.io'),
                     'ss58-prefix' => env('SUBSTRATE_CANARY_SS58_PREFIX', 9030),
                     'genesis-hash' => env('SUBSTRATE_CANARY_GENESIS_HASH', '0xa37725fd8943d2a524cb7ecc65da438f9fa644db78ba24dcd0003e2f95645e8f'),
-                    'spec-version' => env('SUBSTRATE_CANARY_SPEC_VERSION', 1003),
-                    'transaction-version' => env('SUBSTRATE_CANARY_TRANSACTION_VERSION', 5),
+                    'spec-version' => env('SUBSTRATE_CANARY_SPEC_VERSION', 1005),
+                    'transaction-version' => env('SUBSTRATE_CANARY_TRANSACTION_VERSION', 7),
                 ],
                 'local' => [
                     'chain-id' => 0,


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Updated `spec-version` and `transaction-version` in the `enjin-platform.php` configuration file.
- Changes apply to both `enjin` and `canary` configurations, ensuring compatibility with new blockchain specifications.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>enjin-platform.php</strong><dd><code>Update Spec and Transaction Versions for Enjin and Canary</code></dd></summary>
<hr>

config/enjin-platform.php
<li>Updated <code>spec-version</code> from 1003 to 1005 for both <code>enjin</code> and <code>canary</code> <br>configurations.<br> <li> Updated <code>transaction-version</code> from 5 to 7 for both <code>enjin</code> and <code>canary</code> <br>configurations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/139/files#diff-e687a9c8af991f77587526ea6983e8c280929f8ccf6b989eb1eb83c0d8f4d220">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

