### PR TITLE
[PLA-1720] Support for force_mint.

### DIFF
--- a/src/Services/Processor/Substrate/Events/Implementations/MultiTokens/TokenCreated.php
+++ b/src/Services/Processor/Substrate/Events/Implementations/MultiTokens/TokenCreated.php
@@ -64,10 +64,10 @@ class TokenCreated extends SubstrateEvent
         // This is used for TokenCreated events generated on matrixUtility.batch or utility.batch extrinsics
         if (($calls = Arr::get($params, 'calls')) !== null) {
             $calls = collect($calls)->filter(
-                fn ($call) => Arr::get($call, 'MultiTokens.mint') !== null
+                fn ($call) => Arr::get($call, 'MultiTokens.mint') !== null || Arr::get($call, 'MultiTokens.force_mint') !== null
             )->values();
 
-            $params = Arr::get($calls, "{$count}.MultiTokens.mint");
+            $params = Arr::get($calls, "{$count}.MultiTokens.mint") ?? Arr::get($calls, "{$count}.MultiTokens.force_mint");
         }
 
         // This gets the correct recipient from multiTokens.batch_mint
@@ -76,7 +76,7 @@ class TokenCreated extends SubstrateEvent
             $params = collect($recipients)->firstWhere('params.CreateToken.token_id', $event->tokenId);
         }
 
-        $createToken = Arr::get($params, 'params.CreateToken');
+        $createToken = Arr::get($params, 'params.CreateToken') ?? Arr::get($params, 'params.CreateOrMint');
         $isSingleMint = Arr::get($createToken, 'cap.Some') === 'SingleMint' || Arr::has($createToken, 'cap.SingleMint');
         $capSupply = $this->getValue($createToken, ['cap.Some.Supply', 'cap.Supply']);
         $collapsingSupply = $this->getValue($createToken, ['cap.Some.CollapsingSupply', 'cap.CollapsingSupply']);


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
- Added handling for `force_mint` in the token creation event parsing logic alongside existing `mint` handling.
- This update allows the system to recognize and process `force_mint` actions as part of the token creation events.
- Modified the parameter extraction logic to include a fallback to `CreateOrMint` when `CreateToken` is not specified.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TokenCreated.php</strong><dd><code>Support for `force_mint` in Token Creation Event Parsing</code>&nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Events/Implementations/MultiTokens/TokenCreated.php
<li>Added support for <code>force_mint</code> in addition to <code>mint</code> when filtering calls.<br> <li> Ensured that <code>force_mint</code> parameters are considered if <code>mint</code> parameters <br>are not present.<br> <li> Added fallback to <code>CreateOrMint</code> if <code>CreateToken</code> is not available in the <br>parameters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/154/files#diff-17f9b4c3ecdb9bed6779a38eece0cb8fb768cc7785b2a42e16bd63bdfc2217cb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

