### PR TITLE
[PLA-1721] Retry RPC request on sync

### DIFF
--- a/src/Commands/Sync.php
+++ b/src/Commands/Sync.php
@@ -175,6 +175,9 @@ class Sync extends Command
                     $context->send($keyAndHash);
                     [$storage, $total] = $context->join();
 
+                    $this->newLine();
+                    $this->info('Finished to fetch: ' . $storageKey->type->name . ' storage');
+
                     $progress->advance();
 
                     return [$storageKey, $storage, $total];

--- a/src/Commands/contexts/get_storage.php
+++ b/src/Commands/contexts/get_storage.php
@@ -21,15 +21,21 @@ return function (Channel $channel): array {
     $asyncQueries = [];
 
     while (true) {
-        $keys = $rpcKey->send(
-            'state_getKeysPaged',
-            [
-                $storageKey->value,
-                1000,
-                $startKey ?? null,
-                $blockHash,
-            ]
-        );
+        try {
+
+            $keys = $rpcKey->send(
+                'state_getKeysPaged',
+                [
+                    $storageKey->value,
+                    1000,
+                    $startKey ?? null,
+                    $blockHash,
+                ]
+            );
+        } catch (Throwable) {
+            continue;
+        }
+
 
         if (empty($keys)) {
             break;

--- a/src/Commands/contexts/get_storage.php
+++ b/src/Commands/contexts/get_storage.php
@@ -22,7 +22,6 @@ return function (Channel $channel): array {
 
     while (true) {
         try {
-
             $keys = $rpcKey->send(
                 'state_getKeysPaged',
                 [
@@ -35,7 +34,6 @@ return function (Channel $channel): array {
         } catch (Throwable) {
             continue;
         }
-
 
         if (empty($keys)) {
             break;


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Implemented a retry mechanism in `get_storage.php` to handle exceptions during RPC requests.
- The system will now continue to retry the `state_getKeysPaged` RPC request if an exception occurs, enhancing robustness.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>get_storage.php</strong><dd><code>Implement Retry Mechanism for RPC Requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Commands/contexts/get_storage.php
<li>Added a try-catch block around the RPC request to handle exceptions <br>and retry.<br> <li> The loop will continue retrying the request if an exception is caught.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/155/files#diff-c77c549a5f6635a3893e5a46b5ba48ea52f6dddd851a6b7396a720523b57fdfa">+13/-9</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

