### PR TITLE
[PLA-1726] Fixes TokenUnreserved websocket event

### DIFF
--- a/src/Events/Substrate/MultiTokens/TokenUnreserved.php
+++ b/src/Events/Substrate/MultiTokens/TokenUnreserved.php
@@ -2,8 +2,8 @@
 
 namespace Enjin\Platform\Events\Substrate\MultiTokens;
 
-use Enjin\BlockchainTools\HexConverter;
 use Enjin\Platform\Channels\PlatformAppChannel;
+use Enjin\Platform\Enums\Substrate\PalletIdentifier;
 use Enjin\Platform\Events\PlatformBroadcastEvent;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Database\Eloquent\Model;
@@ -23,7 +23,7 @@ class TokenUnreserved extends PlatformBroadcastEvent
             'tokenId' => $token->token_chain_id,
             'wallet' => $wallet->address,
             'amount' => $event->amount,
-            'reserveId' => HexConverter::hexToString($event->reserveId),
+            'reserveId' => PalletIdentifier::from($event->reserveId)->name,
         ];
 
         $this->broadcastChannels = [


### PR DESCRIPTION
## **Type**
bug_fix, enhancement


___

## **Description**
- Updated the `TokenUnreserved` event handling by replacing `HexConverter` with `PalletIdentifier` for reserve ID conversion.
- This change improves the clarity and correctness of reserve ID handling by utilizing a more specific and reliable enum.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TokenUnreserved.php</strong><dd><code>Enhance Reserve ID Handling in TokenUnreserved Event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Events/Substrate/MultiTokens/TokenUnreserved.php
<li>Removed usage of <code>HexConverter</code> for converting reserve IDs.<br> <li> Added usage of <code>PalletIdentifier</code> enum to handle reserve IDs, enhancing <br>readability and reliability.


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/157/files#diff-c8283c89db4ed36305ba66c93694055868c1b849e40a94ef56befa01c1158075">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

