### PR TITLE
[PLA-1739] Return a 400 status code if the GraphQL response contains errors.

### DIFF
--- a/src/Http/Controllers/GraphQLController.php
+++ b/src/Http/Controllers/GraphQLController.php
@@ -35,6 +35,10 @@ class GraphQLController extends GraphQLGraphQLController
             return $this->translateVendorTexts($response);
         }
 
+        if (Arr::has($response->original, 'errors')) {
+            $response->setStatusCode(400);
+        }
+
         return $response;
     }
 


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Added logic in `GraphQLController` to check if the GraphQL response contains errors.
- If errors are found, the HTTP status code is set to 400, indicating a client-side error.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GraphQLController.php</strong><dd><code>Handle GraphQL Errors with HTTP 400 Status Code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Http/Controllers/GraphQLController.php
<li>Added a check for 'errors' in the GraphQL response.<br> <li> Set HTTP status code to 400 if errors are present.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/159/files#diff-5dca1b0a9ac5a0cfbba7020dd56a2f76faf6301ac60e8042e50ca7781c810e9a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

