### PR TITLE
[PLA-1747] Fix prune pending event

### DIFF
--- a/config/enjin-platform.php
+++ b/config/enjin-platform.php
@@ -213,7 +213,7 @@ return [
     | When set to null or zero, expired events will not be pruned.
     |
     */
-    'prune_expired_events' => env('PRUNE_EXPIRED_CLAIMS', 30),
+    'prune_expired_events' => env('PRUNE_EXPIRED_EVENTS', 30),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/CoreServiceProvider.php
+++ b/src/CoreServiceProvider.php
@@ -86,7 +86,7 @@ class CoreServiceProvider extends PackageServiceProvider
         $this->app->register(SerializationServiceProvider::class);
         $this->app->register(BlockchainServiceProvider::class);
         $this->app->register(WebsocketClientProvider::class);
-        $this->app->register(GraphQlServiceProvider::class);
+        //$this->app->register(GraphQlServiceProvider::class);
         $this->app->register(FakerServiceProvider::class);
         $this->app->register(AuthServiceProvider::class);
         $this->app->register(GitHubServiceProvider::class);

--- a/src/CoreServiceProvider.php
+++ b/src/CoreServiceProvider.php
@@ -86,7 +86,7 @@ class CoreServiceProvider extends PackageServiceProvider
         $this->app->register(SerializationServiceProvider::class);
         $this->app->register(BlockchainServiceProvider::class);
         $this->app->register(WebsocketClientProvider::class);
-        //$this->app->register(GraphQlServiceProvider::class);
+        $this->app->register(GraphQlServiceProvider::class);
         $this->app->register(FakerServiceProvider::class);
         $this->app->register(AuthServiceProvider::class);
         $this->app->register(GitHubServiceProvider::class);

--- a/src/Models/Laravel/PendingEvent.php
+++ b/src/Models/Laravel/PendingEvent.php
@@ -50,7 +50,7 @@ class PendingEvent extends BaseModel
     public function prunable()
     {
         if ($days = config('enjin-platform.prune_expired_events')) {
-            return static::where('sent', '<', now()->addDays($days));
+            return static::where('sent', '<=', now()->subDays($days));
         }
 
         return static::where('id', 0);

--- a/tests/Feature/Commands/PruneTest.php
+++ b/tests/Feature/Commands/PruneTest.php
@@ -18,6 +18,14 @@ class PruneTest extends TestCaseGraphQL
         );
         $this->artisan('model:prune', ['--model' => PendingEvent::resolveClassFqn()]);
         $this->assertDatabaseCount('pending_events', 0);
+
+        PendingEvent::insert(
+            PendingEvent::factory(1)->make([
+                'sent' => now()->toDateTimeString(),
+            ])->toArray()
+        );
+        $this->artisan('model:prune', ['--model' => PendingEvent::resolveClassFqn()]);
+        $this->assertDatabaseCount('pending_events', 1);
     }
 
     public function test_it_cannot_prune_expired_events(): void


### PR DESCRIPTION
## **Type**
bug_fix, tests


___

## **Description**
- Corrected the logic in `PendingEvent::prunable()` to properly check for events that are past the expiration date.
- Added a new test to verify that events sent today are not pruned, ensuring that only truly expired events are affected.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PendingEvent.php</strong><dd><code>Fix Prunable Method in PendingEvent Model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Models/Laravel/PendingEvent.php
<li>Changed the condition to correctly identify prunable events based on <br>the 'sent' date.


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/162/files#diff-6caeeb24a4bfce43f6cde67023a004281e1dcfac64a0f3247e24074ad19717f4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PruneTest.php</strong><dd><code>Enhance Prune Command Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/Commands/PruneTest.php
- Added a test case to ensure non-expired events are not pruned.


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/162/files#diff-75d28d1bf3360ab03baf3f9da7e88a6d59a084fd3d9b475dac8e9f06fac23d0e">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

