### PR TITLE
[PLA-1751] Add retries for decoder

### DIFF
--- a/src/Clients/Abstracts/HttpAbstract.php
+++ b/src/Clients/Abstracts/HttpAbstract.php
@@ -16,7 +16,7 @@ abstract class HttpAbstract
     protected function getClient(): PendingRequest
     {
         /** @var PendingRequest $client */
-        return Http::timeout(60)->withoutVerifying()->asJson()->acceptJson();
+        return Http::retry(3, 500)->timeout(60)->withoutVerifying()->asJson()->acceptJson();
     }
 
     /**


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added retry mechanism to HTTP client configuration in `HttpAbstract.php` to enhance reliability.
- Implemented retry logic in `BlockProcessor.php` for fetching events and extrinsics, improving data fetching robustness.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HttpAbstract.php</strong><dd><code>Enhance HTTP Client with Retry Mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Clients/Abstracts/HttpAbstract.php
- Added retry logic to the HTTP client configuration.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/163/files#diff-77c72a39fc283671cf9daed5afd841ac64c4178113bf7728ac276ad2f58aee1c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BlockProcessor.php</strong><dd><code>Implement Retry Logic in BlockProcessor for Events and Extrinsics</code></dd></summary>
<hr>

src/Services/Processor/Substrate/BlockProcessor.php
<li>Introduced a new method <code>waitIfEmpty</code> to handle retries when fetching <br>events or extrinsics.<br> <li> Modified <code>fetchEvents</code> and <code>fetchExtrinsics</code> methods to implement retry <br>logic if the data is initially empty.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/163/files#diff-5e9d1640ff87e611a83e41e14038785fc69b77343a16a046571f964b5f3db954">+22/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

