### PR TITLE
[PLA-1754] Change specVersion for Matrix Canary

### DIFF
--- a/config/enjin-platform.php
+++ b/config/enjin-platform.php
@@ -109,7 +109,7 @@ return [
                     'node' => env('SUBSTRATE_CANARY_RPC', 'wss://rpc.matrix.canary.enjin.io'),
                     'ss58-prefix' => env('SUBSTRATE_CANARY_SS58_PREFIX', 9030),
                     'genesis-hash' => env('SUBSTRATE_CANARY_GENESIS_HASH', '0xa37725fd8943d2a524cb7ecc65da438f9fa644db78ba24dcd0003e2f95645e8f'),
-                    'spec-version' => env('SUBSTRATE_CANARY_SPEC_VERSION', 1005),
+                    'spec-version' => env('SUBSTRATE_CANARY_SPEC_VERSION', 1006),
                     'transaction-version' => env('SUBSTRATE_CANARY_TRANSACTION_VERSION', 7),
                 ],
                 'local' => [


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `spec-version` for the Matrix Canary environment in the configuration file to reflect the new version 1006.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>enjin-platform.php</strong><dd><code>Update Matrix Canary specVersion in Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/enjin-platform.php
<li>Updated the <code>spec-version</code> for the Matrix Canary configuration from 1005 <br>to 1006.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/165/files#diff-e687a9c8af991f77587526ea6983e8c280929f8ccf6b989eb1eb83c0d8f4d220">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

