### PR TITLE
[PLA-1755] Fixes burn mutation validation

### DIFF
--- a/src/GraphQL/Schemas/Primary/Substrate/Mutations/BurnMutation.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Mutations/BurnMutation.php
@@ -119,10 +119,11 @@ class BurnMutation extends Mutation implements PlatformBlockchainTransaction, Pl
      */
     protected function rulesWithValidation(array $args): array
     {
-        $min = Arr::get($args, 'params.removeTokenStorage', false) ? 0 : 1;
+        $removeTokenStorage = Arr::get($args, 'params.removeTokenStorage', false);
+        $min = $removeTokenStorage ? 0 : 1;
 
         return [
-            'collectionId' => ['bail', new IsCollectionOwner()],
+            'collectionId' => ['bail', $removeTokenStorage ? new IsCollectionOwner() : 'exists:collections,collection_chain_id'],
             'params.amount' => [new MinBigInt($min), new MaxTokenBalance()],
             ...$this->getTokenFieldRulesExist('params'),
         ];


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Refactored the `BurnMutation` to improve clarity and correctness in handling the `removeTokenStorage` parameter.
- Updated validation logic in `BurnMutation` to conditionally check collection ownership based on `removeTokenStorage`.
- Enhanced test coverage in `BurnTest` to include new scenarios testing the `removeTokenStorage` functionality.
- Added specific test cases to handle token burning permissions and validations under different conditions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BurnMutation.php</strong><dd><code>Refactor and Enhance Validation in BurnMutation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Substrate/Mutations/BurnMutation.php
<li>Refactored the retrieval of <code>removeTokenStorage</code> from the arguments for <br>clarity.<br> <li> Modified the validation rule for <code>collectionId</code> to check for ownership <br>only if <code>removeTokenStorage</code> is false.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/166/files#diff-43532b8506e2790b4da96f4b575423837403ee2d21843a37450cb557ea1037b0">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BurnTest.php</strong><dd><code>Extend Test Coverage for BurnMutation with New Scenarios</code>&nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/BurnTest.php
<li>Added a test case to verify token burning without being the collection <br>owner when <code>removeTokenStorage</code> is false.<br> <li> Expanded existing test cases to include scenarios with and without <br><code>removeTokenStorage</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/166/files#diff-36454609c810d9e3f7f950e8707561932c4ac32bd9eb5b5d6834a6d9577f99a3">+107/-0</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

