### PR TITLE
[PLA-1757] Fixes hex FuelTanks name

### DIFF
--- a/src/Services/Processor/Substrate/Codec/Polkadart/Events/FuelTanks/FuelTankCreated.php
+++ b/src/Services/Processor/Substrate/Codec/Polkadart/Events/FuelTanks/FuelTankCreated.php
@@ -25,7 +25,7 @@ class FuelTankCreated extends Event implements PolkadartEvent
         $self->module = array_key_first(Arr::get($data, 'event'));
         $self->name = array_key_first(Arr::get($data, 'event.' . $self->module));
         $self->owner = Account::parseAccount($self->getValue($data, ['owner', '0']));
-        $self->tankName = HexConverter::prefix(is_string($value = $self->getValue($data, ['name', '1'])) ? $value : HexConverter::bytesToHex($value));
+        $self->tankName = HexConverter::hexToString(is_string($value = $self->getValue($data, ['name', '1'])) ? $value : HexConverter::bytesToHex($value));
         $self->tankId = HexConverter::prefix(is_string($value = $self->getValue($data, ['tank_id', '2'])) ? $value : HexConverter::bytesToHex($value));
 
         return $self;


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed the method used for converting the tank name from hexadecimal to string in `FuelTankCreated.php`. This ensures the tank name is correctly interpreted and displayed.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FuelTankCreated.php</strong><dd><code>Fix Hex Conversion for Tank Name in FuelTankCreated</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Codec/Polkadart/Events/FuelTanks/FuelTankCreated.php
- Changed method for converting tank name from hex to string.


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/167/files#diff-7e705dde29a65acb39b82223d7385de1ac8ad2dbc0b587fdd55a146978bd3704">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

