### PR TITLE
[PLA-1767] Increases attribute validation size

### DIFF
--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -37,4 +37,5 @@ return [
     'collection_has_tokens' => "The collection doesn't have any tokens.",
     'unused_verification_id' => 'The verification ID is already in use.',
     'account_waiting_collection_transfer' => 'There is no pending collection transfer for the account :account at collection :collectionId.',
+    'string_too_large' => 'The :attribute field is too large.',
 ];

--- a/src/GraphQL/Schemas/Primary/Substrate/Mutations/SetCollectionAttributeMutation.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Mutations/SetCollectionAttributeMutation.php
@@ -16,6 +16,7 @@ use Enjin\Platform\Interfaces\PlatformBlockchainTransaction;
 use Enjin\Platform\Interfaces\PlatformGraphQlMutation;
 use Enjin\Platform\Models\Transaction;
 use Enjin\Platform\Rules\IsCollectionOwner;
+use Enjin\Platform\Rules\StringMaxByteLength;
 use Enjin\Platform\Services\Database\TransactionService;
 use Enjin\Platform\Services\Serialization\Interfaces\SerializationServiceInterface;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -125,8 +126,8 @@ class SetCollectionAttributeMutation extends Mutation implements PlatformBlockch
     protected function rulesCommon(array $args): array
     {
         return [
-            'key' => ['filled', 'alpha_dash', 'max:32'],
-            'value' => ['filled', 'max:255'],
+            'key' => ['filled', 'alpha_dash', new StringMaxByteLength(256)],
+            'value' => ['filled', new StringMaxByteLength(1024)],
         ];
     }
 

--- a/src/GraphQL/Schemas/Primary/Substrate/Mutations/SetTokenAttributeMutation.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Mutations/SetTokenAttributeMutation.php
@@ -19,6 +19,7 @@ use Enjin\Platform\Interfaces\PlatformBlockchainTransaction;
 use Enjin\Platform\Interfaces\PlatformGraphQlMutation;
 use Enjin\Platform\Models\Transaction;
 use Enjin\Platform\Rules\IsCollectionOwner;
+use Enjin\Platform\Rules\StringMaxByteLength;
 use Enjin\Platform\Services\Database\TransactionService;
 use Enjin\Platform\Services\Serialization\Interfaces\SerializationServiceInterface;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -133,8 +134,8 @@ class SetTokenAttributeMutation extends Mutation implements PlatformBlockchainTr
     protected function rulesCommon(array $args): array
     {
         return [
-            'key' => ['filled', 'alpha_dash', 'max:32'],
-            'value' => ['filled', 'max:255'],
+            'key' => ['filled', 'alpha_dash', new StringMaxByteLength(256)],
+            'value' => ['filled', new StringMaxByteLength(1024)],
         ];
     }
 

--- a/src/GraphQL/Types/Input/Substrate/AttributeInputType.php
+++ b/src/GraphQL/Types/Input/Substrate/AttributeInputType.php
@@ -4,6 +4,7 @@ namespace Enjin\Platform\GraphQL\Types\Input\Substrate;
 
 use Enjin\Platform\GraphQL\Types\Traits\InSubstrateSchema;
 use Enjin\Platform\Interfaces\PlatformGraphQlType;
+use Enjin\Platform\Rules\StringMaxByteLength;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Support\InputType;
 
@@ -31,12 +32,12 @@ class AttributeInputType extends InputType implements PlatformGraphQlType
             'key' => [
                 'type' => GraphQL::type('String!'),
                 'description' => __('enjin-platform::mutation.batch_set_attribute.args.key'),
-                'rules' => ['filled', 'alpha_dash'],
+                'rules' => ['filled', 'alpha_dash', new StringMaxByteLength(256)],
             ],
             'value' => [
                 'type' => GraphQL::type('String!'),
                 'description' => __('enjin-platform::mutation.batch_set_attribute.args.value'),
-                'rules' => ['filled'],
+                'rules' => ['filled', new StringMaxByteLength(1024)],
             ],
         ];
     }

--- a/src/Rules/StringMaxByteLength.php
+++ b/src/Rules/StringMaxByteLength.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Enjin\Platform\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class StringMaxByteLength implements ValidationRule
+{
+    /**
+     * Create a new rule instance.
+     */
+    public function __construct($param)
+    {
+        $this->max = $param;
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (filled($value) && (strlen($value) > $this->max)) {
+            $fail('enjin-platform::validation.string_too_large')->translate(['attribute' => $attribute]);
+        }
+    }
+}

--- a/tests/Feature/GraphQL/Mutations/CreateCollectionTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateCollectionTest.php
@@ -1294,6 +1294,50 @@ class CreateCollectionTest extends TestCaseGraphQL
         Event::assertNotDispatched(TransactionCreated::class);
     }
 
+    public function test_it_will_fail_with_invalid_key_length(): void
+    {
+        $response = $this->graphql($this->method, [
+            'mintPolicy' => [
+                'forceSingleMint' => fake()->boolean(),
+            ],
+            'attributes' => [
+                [
+                    'key' => fake()->numerify(str_repeat('#', 257)),
+                    'value' => fake()->realText(),
+                ],
+            ],
+        ], true);
+
+        $this->assertArraySubset(
+            ['attributes.0.key' =>  ['The attributes.0.key field is too large.']],
+            $response['error']
+        );
+
+        Event::assertNotDispatched(TransactionCreated::class);
+    }
+
+    public function test_it_will_fail_with_invalid_value_length(): void
+    {
+        $response = $this->graphql($this->method, [
+            'mintPolicy' => [
+                'forceSingleMint' => fake()->boolean(),
+            ],
+            'attributes' => [
+                [
+                    'key' => fake()->word(),
+                    'value' => fake()->asciify(str_repeat('*', 1025)),
+                ],
+            ],
+        ], true);
+
+        $this->assertArraySubset(
+            ['attributes.0.value' =>  ['The attributes.0.value field is too large.']],
+            $response['error']
+        );
+
+        Event::assertNotDispatched(TransactionCreated::class);
+    }
+
     public function test_it_will_fail_with_duplicate_attributes(): void
     {
         $response = $this->graphql($this->method, [

--- a/tests/Feature/GraphQL/Mutations/SetCollectionAttributeTest.php
+++ b/tests/Feature/GraphQL/Mutations/SetCollectionAttributeTest.php
@@ -198,6 +198,37 @@ class SetCollectionAttributeTest extends TestCaseGraphQL
     }
 
     // Exception Path
+    public function test_it_will_fail_with_invalid_key_length(): void
+    {
+        $response = $this->graphql($this->method, [
+            'collectionId' => $this->collection->collection_chain_id,
+            'key' => fake()->numerify(str_repeat('#', 257)),
+            'value' => fake()->realText(),
+        ], true);
+
+        $this->assertArraySubset(
+            ['key' =>  ['The key field is too large.']],
+            $response['error']
+        );
+
+        Event::assertNotDispatched(TransactionCreated::class);
+    }
+
+    public function test_it_will_fail_with_invalid_value_length(): void
+    {
+        $response = $this->graphql($this->method, [
+            'collectionId' => $this->collection->collection_chain_id,
+            'key' => fake()->word(),
+            'value' => fake()->asciify(str_repeat('*', 1025)),
+        ], true);
+
+        $this->assertArraySubset(
+            ['value' =>  ['The value field is too large.']],
+            $response['error']
+        );
+
+        Event::assertNotDispatched(TransactionCreated::class);
+    }
 
     public function test_it_fail_with_for_collection_that_doesnt_exists(): void
     {

--- a/tests/Feature/GraphQL/Mutations/SetTokenAttributeTest.php
+++ b/tests/Feature/GraphQL/Mutations/SetTokenAttributeTest.php
@@ -339,6 +339,39 @@ class SetTokenAttributeTest extends TestCaseGraphQL
     }
 
     // Exception Path
+    public function test_it_will_fail_with_invalid_key_length(): void
+    {
+        $response = $this->graphql($this->method, [
+            'collectionId' => $this->collection->collection_chain_id,
+            'tokenId' => $this->tokenIdEncoder->toEncodable(),
+            'key' => fake()->numerify(str_repeat('#', 257)),
+            'value' => fake()->realText(),
+        ], true);
+
+        $this->assertArraySubset(
+            ['key' =>  ['The key field is too large.']],
+            $response['error']
+        );
+
+        Event::assertNotDispatched(TransactionCreated::class);
+    }
+
+    public function test_it_will_fail_with_invalid_value_length(): void
+    {
+        $response = $this->graphql($this->method, [
+            'collectionId' => $this->collection->collection_chain_id,
+            'tokenId' => $this->tokenIdEncoder->toEncodable(),
+            'key' => fake()->word(),
+            'value' => fake()->asciify(str_repeat('*', 1025)),
+        ], true);
+
+        $this->assertArraySubset(
+            ['value' =>  ['The value field is too large.']],
+            $response['error']
+        );
+
+        Event::assertNotDispatched(TransactionCreated::class);
+    }
 
     public function test_it_fail_with_for_collection_that_doesnt_exists(): void
     {


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Introduced a new validation rule `StringMaxByteLength` to enforce maximum byte lengths on string attributes.
- Updated attribute validation rules in various mutations to use the new `StringMaxByteLength` rule.
- Added validation error messages for exceeding string size limits.
- Enhanced test coverage to verify the new validation behavior on attribute length constraints.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validation.php</strong><dd><code>Add new validation message for string size</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lang/en/validation.php
<li>Added a new validation message for excessively large string fields.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/169/files#diff-31a31d40d62ce50b5e434f851645fcfd67a47eb50238e32468433a863a737182">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SetCollectionAttributeMutation.php</strong><dd><code>Update attribute validation in SetCollectionAttributeMutation</code></dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Substrate/Mutations/SetCollectionAttributeMutation.php
<li>Updated validation rules for 'key' and 'value' to use new <br>StringMaxByteLength rule.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/169/files#diff-6a04f0792d9e892ff57df1e1f8a99906da615cb5a3fb017ae2381d9b8d3c8331">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SetTokenAttributeMutation.php</strong><dd><code>Update attribute validation in SetTokenAttributeMutation</code>&nbsp; </dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Substrate/Mutations/SetTokenAttributeMutation.php
<li>Updated validation rules for 'key' and 'value' to use new <br>StringMaxByteLength rule.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/169/files#diff-8a5f14331857fe69ad77899645be06dd462d3a0fa9b3341223e8ac5657fe0461">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AttributeInputType.php</strong><dd><code>Update attribute validation rules in AttributeInputType</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Types/Input/Substrate/AttributeInputType.php
<li>Updated validation rules for 'key' and 'value' to use new <br>StringMaxByteLength rule.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/169/files#diff-9e4917e73aa71e664ae1b9cb9f5181090c2d320f466b8b628eacf905a2501c27">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>StringMaxByteLength.php</strong><dd><code>Implement new StringMaxByteLength validation rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Rules/StringMaxByteLength.php
<li>Implemented a new validation rule class to check the maximum byte <br>length of a string.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/169/files#diff-4ec54e7910cff6d5d2e0b362cb7fb020994d45fcc5d751b12cf6a8e8690094b2">+29/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreateCollectionTest.php</strong><dd><code>Add tests for attribute length validation in CreateCollectionTest</code></dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/CreateCollectionTest.php
<li>Added tests to verify failure on exceeding maximum key and value <br>lengths.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/169/files#diff-914a12ec8d155731d6daa1adc26da167ef5af1e001adc7252497eca8fb6997a7">+44/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SetCollectionAttributeTest.php</strong><dd><code>Add tests for attribute length validation in </code><br><code>SetCollectionAttributeTest</code></dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/SetCollectionAttributeTest.php
<li>Added tests to verify failure on exceeding maximum key and value <br>lengths.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/169/files#diff-8b6e636de79f7b5975ba8be5aef5b0c29909782e13cd0d84299178f23cde2cfe">+31/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SetTokenAttributeTest.php</strong><dd><code>Add tests for attribute length validation in SetTokenAttributeTest</code></dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/SetTokenAttributeTest.php
<li>Added tests to verify failure on exceeding maximum key and value <br>lengths.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/169/files#diff-e8e49795c1bb7a5c752b537e0aa6edf254181e0f397e9221cbd6b4d685289570">+33/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

