### PR TITLE
[PLA-1769] Fire transaction created event on relay watcher

### DIFF
--- a/src/Commands/RelayWatcher.php
+++ b/src/Commands/RelayWatcher.php
@@ -9,6 +9,7 @@ use Enjin\Platform\Enums\Global\PlatformCache;
 use Enjin\Platform\Enums\Global\TransactionState;
 use Enjin\Platform\Enums\Substrate\StorageKey;
 use Enjin\Platform\Enums\Substrate\SystemEventType;
+use Enjin\Platform\Events\Global\TransactionCreated;
 use Enjin\Platform\Models\Transaction;
 use Enjin\Platform\Models\Wallet;
 use Enjin\Platform\Services\Blockchain\Implementations\Substrate;
@@ -129,7 +130,6 @@ class RelayWatcher extends Command
                     $tx->save();
 
                     $this->updateExtrinsicResult($blockHash, $i, $tx->id, null);
-
                 }
             }
         }
@@ -214,7 +214,7 @@ class RelayWatcher extends Command
         $call .= '030400000000' . HexConverter::unPrefix($amount);
         $call .= '0000000000';
 
-        Transaction::create([
+        $transaction = Transaction::create([
             'wallet_public_key' => $managedWallet->public_key,
             'method' => 'LimitedTeleportAssets',
             'state' => TransactionState::PENDING->name,
@@ -223,6 +223,8 @@ class RelayWatcher extends Command
             'idempotency_key' => Str::uuid(),
         ]);
 
+        TransactionCreated::safeBroadcast($transaction);
+
         // 63 09 = callIndex = (u8; u8)
         // 03 = dest = XcmVersionedMultiLocation (XcmV3MultiLocation)
         // 00 = parents = u8
@@ -230,7 +232,7 @@ class RelayWatcher extends Command
         // 03 = beneficiary = XcmVersionedMultiLocation (XcmV3MultiLocation)
         // 00 = parents = u8
         // 01 01 = interior = XcmV3Juntions (XcmV3Junction X1) AccountId32
-        // 00 = network = Network = Option<XcmV3JunctionNetworkId>
+        // 00 = network = Network = Option<\\]=lslslsllsllaldlsdp;0lsls>
         // c660fef4c0926e382839d20caee6d4e3adb4d27ec66b223ed6456845196e3e79 = id = [u8;32]
         // 03 04 = assets = Vec<XcmV3MultiassetMultiAssets> (V3)
         // 00 = id = XcmV3MultiassetAssetId (Concrete)

--- a/src/Commands/RelayWatcher.php
+++ b/src/Commands/RelayWatcher.php
@@ -232,7 +232,7 @@ class RelayWatcher extends Command
         // 03 = beneficiary = XcmVersionedMultiLocation (XcmV3MultiLocation)
         // 00 = parents = u8
         // 01 01 = interior = XcmV3Juntions (XcmV3Junction X1) AccountId32
-        // 00 = network = Network = Option<\\]=lslslsllsllaldlsdp;0lsls>
+        // 00 = network = Network = Option<XcmV3JunctionNetworkId>
         // c660fef4c0926e382839d20caee6d4e3adb4d27ec66b223ed6456845196e3e79 = id = [u8;32]
         // 03 04 = assets = Vec<XcmV3MultiassetMultiAssets> (V3)
         // 00 = id = XcmV3MultiassetAssetId (Concrete)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added the `TransactionCreated` event broadcast to the `createDaemonTransaction` method in `RelayWatcher.php` to enhance transaction handling.
- Imported the necessary `TransactionCreated` class to enable event broadcasting.
- Stored the result of `Transaction::create` in a variable to use for event broadcasting.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RelayWatcher.php</strong><dd><code>Implement Transaction Created Event Broadcast in RelayWatcher</code></dd></summary>
<hr>

src/Commands/RelayWatcher.php
<li>Added import for <code>TransactionCreated</code> event.<br> <li> Modified <code>createDaemonTransaction</code> to store the created transaction in a <br>variable and broadcast a <code>TransactionCreated</code> event.<br> <li> Minor formatting changes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/170/files#diff-48110bb63d25893338956f8dcdb6ba722c4671edff58ddeedcbae42d6552e617">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

