### PR TITLE
[PLA-1770] Adds Balances.Teleport + LimitedTeleportAssets method.

### DIFF
--- a/src/Commands/RelayWatcher.php
+++ b/src/Commands/RelayWatcher.php
@@ -230,9 +230,9 @@ class RelayWatcher extends Command
             'public_key' => $account,
         ]);
 
-        $amount = $this->codec->encoder()->compact($amount);
+        $transferableAmount = $this->codec->encoder()->compact(gmp_sub(gmp_init($amount), gmp_init(100000000000000000)));
         $call = '0x630903000100a10f0300010100' . HexConverter::unPrefix($managedWallet->public_key);
-        $call .= '030400000000' . HexConverter::unPrefix($amount);
+        $call .= '030400000000' . HexConverter::unPrefix($transferableAmount);
         $call .= '0000000000';
 
         $transaction = Transaction::create([

--- a/src/Commands/RelayWatcher.php
+++ b/src/Commands/RelayWatcher.php
@@ -230,7 +230,9 @@ class RelayWatcher extends Command
             'public_key' => $account,
         ]);
 
-        $transferableAmount = $this->codec->encoder()->compact(gmp_sub(gmp_init($amount), gmp_init(100000000000000000)));
+        $transferableAmount = $this->codec->encoder()->compact(
+            gmp_strval(gmp_sub($amount, '100000000000000000'))
+        );
         $call = '0x630903000100a10f0300010100' . HexConverter::unPrefix($managedWallet->public_key);
         $call .= '030400000000' . HexConverter::unPrefix($transferableAmount);
         $call .= '0000000000';

--- a/src/Enums/Substrate/XcmOutcome.php
+++ b/src/Enums/Substrate/XcmOutcome.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Enjin\Platform\Enums\Substrate;
+
+use Enjin\Platform\Traits\EnumExtensions;
+
+enum XcmOutcome: string
+{
+    use EnumExtensions;
+
+    case COMPLETE = 'Complete';
+    case INCOMPLETE = 'Incomplete';
+}

--- a/src/Events/Substrate/Balances/Teleport.php
+++ b/src/Events/Substrate/Balances/Teleport.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Enjin\Platform\Events\Substrate\Balances;
+
+use Enjin\Platform\Channels\PlatformAppChannel;
+use Enjin\Platform\Events\PlatformBroadcastEvent;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Database\Eloquent\Model;
+
+class Teleport extends PlatformBroadcastEvent
+{
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(Model $from, Model $to, string $amount, string $destination, ?Model $transaction = null)
+    {
+        parent::__construct();
+
+        $this->broadcastData = [
+            'idempotencyKey' => $transaction?->idempotency_key,
+            'transactionHash' => $transaction?->transaction_chain_hash,
+            'from' => $from->address,
+            'to' => $to->address,
+            'amount' => $amount,
+            'destination' => $destination,
+        ];
+
+        $this->broadcastChannels = [
+            new Channel($from->address),
+            new Channel($to->address),
+            new PlatformAppChannel(),
+        ];
+    }
+}

--- a/src/GraphQL/Enums/TransactionMethodEnum.php
+++ b/src/GraphQL/Enums/TransactionMethodEnum.php
@@ -15,7 +15,7 @@ class TransactionMethodEnum extends EnumType implements PlatformGraphQlEnum
     {
         // TODO: Need to check the implications of removing:
         // This '' causes an error on graphql
-        $mutationNames = collect([]);
+        $mutationNames = collect(['LimitedTeleportAssets']);
         foreach (get_declared_classes() as $className) {
             if (in_array(PlatformBlockchainTransaction::class, class_implements($className))) {
                 $mutationNames->add((new $className())->getMutationName());

--- a/src/Services/Processor/Substrate/Codec/Polkadart/Events/XcmPallet/Attempted.php
+++ b/src/Services/Processor/Substrate/Codec/Polkadart/Events/XcmPallet/Attempted.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Enjin\Platform\Services\Processor\Substrate\Codec\Polkadart\Events\XcmPallet;
+
+use Enjin\Platform\Enums\Substrate\XcmOutcome;
+use Enjin\Platform\Services\Processor\Substrate\Codec\Polkadart\Events\Event;
+use Enjin\Platform\Services\Processor\Substrate\Codec\Polkadart\PolkadartEvent;
+use Illuminate\Support\Arr;
+
+class Attempted extends Event implements PolkadartEvent
+{
+    public readonly ?string $extrinsicIndex;
+    public readonly string $module;
+    public readonly string $name;
+    public readonly XcmOutcome $outcome;
+
+    public static function fromChain(array $data): self
+    {
+        $self = new self();
+
+        $self->extrinsicIndex = Arr::get($data, 'phase.ApplyExtrinsic');
+        $self->module = array_key_first(Arr::get($data, 'event'));
+        $self->name = array_key_first(Arr::get($data, 'event.' . $self->module));
+        $self->outcome = XcmOutcome::tryFrom(array_key_first($self->getValue($data, ['xcm::latest::Outcome']))) ?? XcmOutcome::INCOMPLETE;
+
+        return $self;
+    }
+
+    public function getPallet(): string
+    {
+        return $this->module;
+    }
+
+    public function getParams(): array
+    {
+        return [
+            ['type' => 'outcome', 'value' => $this->outcome],
+        ];
+    }
+}
+
+// - Complete
+// +extrinsicIndex: "2"
+// +module: "XcmPallet"
+// +name: "Attempted"
+// +data: array:1 [▼
+//    "xcm::latest::Outcome" => array:1 [▼
+//      "Complete" => array:2 [▼
+//        "ref_time" => "450000000"
+//        "proof_size" => "3072"
+//      ]
+//    ]
+//  ]
+//  +outcome: "Complete"
+//
+//
+// - Incomplete
+// +extrinsicIndex: "2"
+// +module: "XcmPallet"
+// +name: "Attempted"
+// +data: array:1 [▼
+//    "xcm::latest::Outcome" => array:1 [▼
+//      "Incomplete" => array:2 [▼
+//        0 => array:2 [▼
+//          "ref_time" => "150000000"
+//          "proof_size" => "1024"
+//        ]
+//        1 => array:1 [▼
+//          "FailedToTransactAsset" => null
+//        ]
+//      ]
+//    ]
+//  ]
+//  +outcome: "Incomplete"


### PR DESCRIPTION
### **PR Type**
enhancement, bug_fix


___

### **Description**
- Introduced new event handling for `Teleport` transactions and outcomes using the `XcmOutcome` enum.
- Enhanced transaction update logic in `RelayWatcher.php` to improve accuracy of transaction state updates.
- Added new enum `XcmOutcome` and a new event class `Teleport` to handle specific substrate balance operations.
- Updated GraphQL enum to include new transaction method `LimitedTeleportAssets`.
- Implemented new event class `Attempted` to process specific events from the XcmPallet.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RelayWatcher.php</strong><dd><code>Enhance transaction handling and add new event processing</code></dd></summary>
<hr>

src/Commands/RelayWatcher.php
<li>Added handling for new <code>Teleport</code> event and <code>XcmOutcome</code> enum.<br> <li> Improved transaction update logic to handle success and failure more <br>accurately.<br> <li> Extended caching duration for extrinsic identifiers.


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/171/files#diff-48110bb63d25893338956f8dcdb6ba722c4671edff58ddeedcbae42d6552e617">+43/-22</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>XcmOutcome.php</strong><dd><code>Add XcmOutcome enum for transaction outcomes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Enums/Substrate/XcmOutcome.php
<li>Introduced a new enum <code>XcmOutcome</code> with values <code>COMPLETE</code> and <code>INCOMPLETE</code>.


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/171/files#diff-92d5022b891c18834cbd9ab77d67e24ead6a7784cc1536adafcbe2d0a6387b1e">+13/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Teleport.php</strong><dd><code>Implement Teleport event for substrate balances</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Events/Substrate/Balances/Teleport.php
<li>Created a new event class <code>Teleport</code> to handle teleport transactions.<br> <li> Event broadcasts transaction details to specific channels.


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/171/files#diff-5f017e3d8121564a4ec2e0e9f4829c1faf19b3c3b3662cf120e69d384dfd4c48">+34/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>TransactionMethodEnum.php</strong><dd><code>Update GraphQL transaction methods enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Enums/TransactionMethodEnum.php
- Added 'LimitedTeleportAssets' to the list of mutation names.


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/171/files#diff-0846347c6f330e6193383007fd127015a6e31ae61fd39dfe0f1d227be5b2462a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Attempted.php</strong><dd><code>Add handling for XcmPallet 'Attempted' events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Codec/Polkadart/Events/XcmPallet/Attempted.php
<li>Added a new class to handle 'Attempted' events from the XcmPallet.<br> <li> Handles outcome determination based on transaction data.


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/171/files#diff-259103c0e8d983ef7d381f9ca5d7f64765a2158b885ce5f97e887a0e4a6e58c9">+74/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

