### PR TITLE
[Hotfix] Fixes platform:sync on SYNC_ALL

### DIFF
--- a/src/Commands/Sync.php
+++ b/src/Commands/Sync.php
@@ -198,7 +198,7 @@ class Sync extends Command
             ->where('syncable_type', ModelType::COLLECTION)
             ->pluck('syncable_id');
 
-        if (empty($collectionFilter)) {
+        if (config('enjin-platform.sync.all')) {
             return Substrate::getStorageKeys();
         }
 

--- a/src/Commands/Sync.php
+++ b/src/Commands/Sync.php
@@ -197,7 +197,7 @@ class Sync extends Command
         if (config('enjin-platform.sync.all')) {
             return Substrate::getStorageKeys();
         }
-        
+
         $collectionFilter = Syncable::query()
             ->where('syncable_type', ModelType::COLLECTION)
             ->pluck('syncable_id');

--- a/src/Commands/Sync.php
+++ b/src/Commands/Sync.php
@@ -194,13 +194,13 @@ class Sync extends Command
 
     protected function getKeys(): array
     {
-        $collectionFilter = Syncable::query()
-            ->where('syncable_type', ModelType::COLLECTION)
-            ->pluck('syncable_id');
-
         if (config('enjin-platform.sync.all')) {
             return Substrate::getStorageKeys();
         }
+        
+        $collectionFilter = Syncable::query()
+            ->where('syncable_type', ModelType::COLLECTION)
+            ->pluck('syncable_id');
 
         return Substrate::getStorageKeysForCollectionIds($collectionFilter);
     }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the condition in the `getKeys` method to check the `config('enjin-platform.sync.all')` setting instead of whether `collectionFilter` is empty.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Sync.php</strong><dd><code>Update condition to use configuration setting for sync</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Commands/Sync.php
<li>Modified the condition to check <code>config('enjin-platform.sync.all')</code> <br>instead of <code>empty($collectionFilter)</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/175/files#diff-9b0a60cf1d209941117e6dc62d39f195a8fb08d7e6510e532321c5ee01c6f66b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

