### PR TITLE
[PLA-1806] Fixes wrong var

### DIFF
--- a/src/Services/Processor/Substrate/Events/Implementations/MultiTokens/Minted.php
+++ b/src/Services/Processor/Substrate/Events/Implementations/MultiTokens/Minted.php
@@ -34,7 +34,7 @@ class Minted extends SubstrateEvent
         $recipient = $this->firstOrStoreAccount($this->event->recipient);
 
         $this->tokenMinted->update([
-            'supply', gmp_strval(gmp_add($token->supply, $this->event->amount)) ?? 0,
+            'supply', gmp_strval(gmp_add($this->tokenMinted->supply, $this->event->amount)) ?? 0,
         ]);
 
         TokenAccount::where([


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue in `Minted.php` where the wrong variable was used to update the token supply.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Minted.php</strong><dd><code>Fix incorrect variable in token supply update.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Events/Implementations/MultiTokens/Minted.php
- Corrected variable used in updating token supply.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/177/files#diff-0689f287583f607993f60089eec05b58ecc23476db6c6a88c81b0db3f593048e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

