### PR TITLE
[PLA-1855] Fixes for hex encoded attribute keys and values.

### DIFF
--- a/src/Services/Database/TokenService.php
+++ b/src/Services/Database/TokenService.php
@@ -2,6 +2,7 @@
 
 namespace Enjin\Platform\Services\Database;
 
+use Enjin\BlockchainTools\HexConverter;
 use Enjin\Platform\Exceptions\PlatformException;
 use Enjin\Platform\Models\Attribute;
 use Enjin\Platform\Models\Laravel\Collection;
@@ -110,7 +111,7 @@ class TokenService
 
         return Attribute::withoutGlobalScopes()->whereCollectionId($collection->id)
             ->whereTokenId($token->id)
-            ->where('key', '=', $key)
+            ->where('key', '=', HexConverter::stringToHexPrefixed($key))
             ->exists();
     }
 

--- a/src/Services/Processor/Substrate/Events/Implementations/MultiTokens/AttributeSet.php
+++ b/src/Services/Processor/Substrate/Events/Implementations/MultiTokens/AttributeSet.php
@@ -2,6 +2,7 @@
 
 namespace Enjin\Platform\Services\Processor\Substrate\Events\Implementations\MultiTokens;
 
+use Enjin\BlockchainTools\HexConverter;
 use Enjin\Platform\Events\Substrate\MultiTokens\CollectionAttributeSet;
 use Enjin\Platform\Events\Substrate\MultiTokens\TokenAttributeSet;
 use Enjin\Platform\Exceptions\PlatformException;
@@ -38,10 +39,10 @@ class AttributeSet extends SubstrateEvent
             [
                 'collection_id' => $collection->id,
                 'token_id' => $token?->id,
-                'key' => $this->event->key,
+                'key' => HexConverter::prefix($this->event->key),
             ],
             [
-                'value' => $this->event->value,
+                'value' => HexConverter::prefix($this->event->value),
             ]
         );
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added `HexConverter` to convert and prefix attribute keys and values in `TokenService` and `AttributeSet` event.
- Ensured attribute keys are converted to hex in the `attributeExistsInToken` validation rule.
- Ensured attribute keys and values are prefixed when added via the `AttributeSet` substrate event.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TokenService.php</strong><dd><code>Convert attribute keys to hex in TokenService.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Database/TokenService.php
<li>Added <code>HexConverter</code> usage to convert attribute keys to hex format.<br> <li> Ensured attribute key is converted to hex in <code>attributeExistsInToken</code> <br>method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/179/files#diff-556ec2a8425249ea520d2afa8329f820e881bca496e248b4e7d7d70603e9e346">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AttributeSet.php</strong><dd><code>Prefix attribute keys and values in AttributeSet event.</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Events/Implementations/MultiTokens/AttributeSet.php
<li>Added <code>HexConverter</code> usage to prefix attribute keys and values.<br> <li> Ensured attribute keys and values are prefixed when added via the <br><code>AttributeSet</code> event.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/179/files#diff-c0590b117927a4fdc6470abee96df552846588c56a20cdef406e857aec39582c">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

