### PR TITLE
[PLA-1838] Fixes token freeze with nullable freezeState

### DIFF
--- a/src/GraphQL/Schemas/Primary/Substrate/Mutations/FreezeMutation.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Mutations/FreezeMutation.php
@@ -111,7 +111,7 @@ class FreezeMutation extends Mutation implements PlatformBlockchainTransaction, 
     ): mixed {
         $params = $blockchainService->getFreezeOrThawParams($args);
 
-        if (is_null($params->freezeState)) {
+        if (is_null($params->freezeState) && $params->type === FreezeType::TOKEN) {
             $params->freezeState = FreezeStateType::TEMPORARY;
         }
 

--- a/src/GraphQL/Schemas/Primary/Substrate/Mutations/FreezeMutation.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Mutations/FreezeMutation.php
@@ -110,11 +110,6 @@ class FreezeMutation extends Mutation implements PlatformBlockchainTransaction, 
         TransactionService $transactionService
     ): mixed {
         $params = $blockchainService->getFreezeOrThawParams($args);
-
-        if (is_null($params->freezeState) && $params->type === FreezeType::TOKEN) {
-            $params->freezeState = FreezeStateType::TEMPORARY;
-        }
-
         $encodedData = $serializationService->encode($this->getMutationName(), static::getEncodableParams(
             collectionId: $args['collectionId'],
             freezeParams: $params
@@ -128,9 +123,15 @@ class FreezeMutation extends Mutation implements PlatformBlockchainTransaction, 
 
     public static function getEncodableParams(...$params): array
     {
+        $freezeType = Arr::get($params, 'freezeParams', new FreezeTypeParams(FreezeType::TOKEN));
+
+        if (is_null($freezeType->freezeState) && $freezeType->type === FreezeType::TOKEN) {
+            $freezeType->freezeState = FreezeStateType::TEMPORARY;
+        }
+
         return [
             'collectionId' => gmp_init(Arr::get($params, 'collectionId', 0)),
-            'freezeType' => Arr::get($params, 'freezeParams', new FreezeTypeParams(FreezeType::TOKEN))->toEncodable(),
+            'freezeType' => $freezeType->toEncodable(),
         ];
     }
 

--- a/src/GraphQL/Schemas/Primary/Substrate/Mutations/FreezeMutation.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Mutations/FreezeMutation.php
@@ -3,6 +3,7 @@
 namespace Enjin\Platform\GraphQL\Schemas\Primary\Substrate\Mutations;
 
 use Closure;
+use Enjin\Platform\Enums\Substrate\FreezeStateType;
 use Enjin\Platform\Enums\Substrate\FreezeType;
 use Enjin\Platform\GraphQL\Base\Mutation;
 use Enjin\Platform\GraphQL\Schemas\Primary\Substrate\Traits\InPrimarySubstrateSchema;
@@ -109,6 +110,11 @@ class FreezeMutation extends Mutation implements PlatformBlockchainTransaction, 
         TransactionService $transactionService
     ): mixed {
         $params = $blockchainService->getFreezeOrThawParams($args);
+
+        if (is_null($params->freezeState)) {
+            $params->freezeState = FreezeStateType::TEMPORARY;
+        }
+
         $encodedData = $serializationService->encode($this->getMutationName(), static::getEncodableParams(
             collectionId: $args['collectionId'],
             freezeParams: $params

--- a/src/Models/Substrate/FreezeTypeParams.php
+++ b/src/Models/Substrate/FreezeTypeParams.php
@@ -45,7 +45,7 @@ class FreezeTypeParams
             FreezeType::TOKEN => [
                 'Token' => [
                     'tokenId' => gmp_init($this->token),
-                    'freezeState' => $this->freezeState?->value,
+                    'freezeState' => $this->freezeState?->value ?? FreezeStateType::TEMPORARY->value,
                 ],
             ],
             FreezeType::COLLECTION_ACCOUNT => [

--- a/src/Models/Substrate/FreezeTypeParams.php
+++ b/src/Models/Substrate/FreezeTypeParams.php
@@ -45,7 +45,7 @@ class FreezeTypeParams
             FreezeType::TOKEN => [
                 'Token' => [
                     'tokenId' => gmp_init($this->token),
-                    'freezeState' => $this->freezeState?->value ?? FreezeStateType::TEMPORARY->value,
+                    'freezeState' => $this->freezeState?->value,
                 ],
             ],
             FreezeType::COLLECTION_ACCOUNT => [

--- a/tests/Feature/GraphQL/Mutations/FreezeTest.php
+++ b/tests/Feature/GraphQL/Mutations/FreezeTest.php
@@ -372,7 +372,7 @@ class FreezeTest extends TestCaseGraphQL
         ]);
     }
 
-    public function test_can_freeze_a_token(): void
+    public function test_can_freeze_a_token_without_freeze_state(): void
     {
         $encodedData = TransactionSerializer::encode($this->method, FreezeMutation::getEncodableParams(
             collectionId: $collectionId = $this->collection->collection_chain_id,

--- a/tests/Unit/EncodingTest.php
+++ b/tests/Unit/EncodingTest.php
@@ -1033,7 +1033,7 @@ class EncodingTest extends TestCase
 
         $callIndex = $this->codec->encoder()->getCallIndex('MultiTokens.freeze', true);
         $this->assertEquals(
-            "0x{$callIndex}b67a030001ff0000000000000000000000000000000100",
+            "0x{$callIndex}b67a030001ff0000000000000000000000000000000101",
             $data
         );
     }

--- a/tests/Unit/EncodingTest.php
+++ b/tests/Unit/EncodingTest.php
@@ -1033,7 +1033,7 @@ class EncodingTest extends TestCase
 
         $callIndex = $this->codec->encoder()->getCallIndex('MultiTokens.freeze', true);
         $this->assertEquals(
-            "0x{$callIndex}b67a030001ff00000000000000000000000000000000",
+            "0x{$callIndex}b67a030001ff0000000000000000000000000000000100",
             $data
         );
     }


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed the issue where `freezeState` could be null by setting a default value of `FreezeStateType::TEMPORARY->value` in `FreezeTypeParams`.
- Removed an unused import `HexConverter` from `ExtrinsicProcessor`.
- Renamed a test method to `test_can_freeze_a_token_without_freeze_state` to reflect the test's purpose more accurately.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FreezeTypeParams.php</strong><dd><code>Fix token freeze with nullable <code>freezeState</code> by setting default value.</code></dd></summary>
<hr>

src/Models/Substrate/FreezeTypeParams.php
<li>Updated <code>freezeState</code> to default to <code>FreezeStateType::TEMPORARY->value</code> if <br>null.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/187/files#diff-593bd6e2247d70042bccd037b590f35999976b97d3d7d6df49d8c435152283a3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Miscellaneous
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ExtrinsicProcessor.php</strong><dd><code>Remove unused import in `ExtrinsicProcessor`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/ExtrinsicProcessor.php
- Removed unused import `HexConverter`.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/187/files#diff-4fcc9c507292feff5eef58370b514f726b3400ee7d1d19916508f415aef605ea">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FreezeTest.php</strong><dd><code>Rename test method for freezing token without `freezeState`.</code></dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/FreezeTest.php
<li>Renamed test method to <code>test_can_freeze_a_token_without_freeze_state</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/187/files#diff-2ca38066055f81df2eb25bf792a4bf2df84641f9803aa785a4df5c4e87d348ba">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

