### PR TITLE
[PLA-1878] Marketplace mutations support to v1010

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "phpstan/phpstan-phpunit": "^1.0",
     "phpunit/php-code-coverage": "^10.0",
     "phpunit/phpunit": "^10.0",
-    "rector/rector": "^1.2",
+    "rector/rector": "^1.0",
     "roave/security-advisories": "dev-latest"
   },
   "autoload": {

--- a/src/Services/Processor/Substrate/Codec/Types/CreateListing.json
+++ b/src/Services/Processor/Substrate/Codec/Types/CreateListing.json
@@ -11,5 +11,25 @@
     "AuctionData": {
         "startBlock": "Compact<u32>",
         "endBlock": "Compact<u32>"
+    },
+    "CreateListingV1010": {
+        "callIndex": "(u8, u8)",
+        "makeAssetId": "MultiTokensAssetId",
+        "takeAssetId": "MultiTokensAssetId",
+        "amount": "Compact<u128>",
+        "price": "Compact<u128>",
+        "salt": "Bytes",
+        "listingData": "ListingDataV1010",
+        "depositor": "Option<AccountId>"
+    },
+    "ListingDataV1010": {
+        "_enum": {
+            "FixedPrice": "Null",
+            "Auction": "AuctionData",
+            "Offer": "OfferData"
+        }
+    },
+    "OfferData": {
+        "expiration": "Option<u32>"
     }
 }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Downgraded `rector/rector` dependency from version 1.2 to 1.0 in `composer.json`.
- Added new types `CreateListingV1010`, `ListingDataV1010`, and `OfferData` in `CreateListing.json` to support marketplace mutations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>composer.json</strong><dd><code>Downgrade `rector/rector` dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

composer.json

- Downgraded `rector/rector` dependency from version 1.2 to 1.0.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/198/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreateListing.json</strong><dd><code>Add new types for marketplace mutations support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Codec/Types/CreateListing.json

<li>Added <code>CreateListingV1010</code> type with various fields.<br> <li> Added <code>ListingDataV1010</code> type with an enum.<br> <li> Added <code>OfferData</code> type with an expiration field.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/198/files#diff-5e3dca1bcb78914dc5fd2849173a1dbd07ecb47bbe980919b4d0946315a235fd">+20/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

