### PR TITLE
[PLA-1885] Relay-watcher changes

### DIFF
--- a/src/Commands/RelayWatcher.php
+++ b/src/Commands/RelayWatcher.php
@@ -208,11 +208,15 @@ class RelayWatcher extends Command
 
             if ($explode[1]) {
                 $tx->result = SystemEventType::EXTRINSIC_SUCCESS->name;
+
                 Teleport::safeBroadcast(
-                    $wallet = Wallet::firstWhere('public_key', $tx->wallet_public_key),
-                    $wallet,
-                    $tx->amount,
-                    currentMatrix()->value,
+                    [
+                        'from' => $tx->wallet_public_key,
+                        'to' => $tx->wallet_public_key,
+                        'amount' => $tx->amount,
+                        'destination' => currentMatrix()->value,
+                    ],
+                    $tx
                 );
             }
 

--- a/src/Events/Substrate/Balances/Teleport.php
+++ b/src/Events/Substrate/Balances/Teleport.php
@@ -12,22 +12,22 @@ class Teleport extends PlatformBroadcastEvent
     /**
      * Create a new event instance.
      */
-    public function __construct(Model $from, Model $to, string $amount, string $destination, ?Model $transaction = null)
+    public function __construct(mixed $event, ?Model $transaction = null)
     {
         parent::__construct();
 
         $this->broadcastData = [
             'idempotencyKey' => $transaction?->idempotency_key,
             'transactionHash' => $transaction?->transaction_chain_hash,
-            'from' => $from->public_key,
-            'to' => $to->public_key,
-            'amount' => $amount,
-            'destination' => $destination,
+            'from' => $event->from,
+            'to' => $event->to,
+            'amount' => $event->amount,
+            'destination' => $event->destination,
         ];
 
         $this->broadcastChannels = [
-            new Channel($from->public_key),
-            new Channel($to->public_key),
+            new Channel($event->from),
+            new Channel($event->to),
             new PlatformAppChannel(),
         ];
     }


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated `Teleport::safeBroadcast` method call in `RelayWatcher` to use an associative array for parameters.
- Refactored `Teleport` class constructor to accept a mixed type `event` parameter and updated its properties accordingly.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RelayWatcher.php</strong><dd><code>Update Teleport::safeBroadcast call with associative array</code></dd></summary>
<hr>

src/Commands/RelayWatcher.php

<li>Modified the <code>Teleport::safeBroadcast</code> method call to use an associative <br>array for parameters.<br> <li> Updated the parameters passed to <code>Teleport::safeBroadcast</code> to include <br>'from', 'to', 'amount', and 'destination'.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/203/files#diff-48110bb63d25893338956f8dcdb6ba722c4671edff58ddeedcbae42d6552e617">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Teleport.php</strong><dd><code>Refactor Teleport constructor to use event object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Events/Substrate/Balances/Teleport.php

<li>Changed the constructor of the <code>Teleport</code> class to accept a mixed type <br><code>event</code> parameter.<br> <li> Updated the broadcast data and channels to use properties from the <br><code>event</code> object.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/203/files#diff-5f017e3d8121564a4ec2e0e9f4829c1faf19b3c3b3662cf120e69d384dfd4c48">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

