### PR TITLE
[PLA-1897] Fix setAttribute callIndex

### DIFF
--- a/src/Services/Processor/Substrate/Codec/Encoder.php
+++ b/src/Services/Processor/Substrate/Codec/Encoder.php
@@ -24,7 +24,7 @@ class Encoder
 
     protected static array $callIndexKeys = [
         'Batch' => 'MatrixUtility.batch',
-        'TransferBalance' => 'Balances.transfer',
+        'TransferBalance' => 'Balances.transfer_keep_alive',
         'TransferBalanceKeepAlive' => 'Balances.transfer_keep_alive',
         'TransferAllBalance' => 'Balances.transfer_all',
         'ApproveCollection' => 'MultiTokens.approve_collection',

--- a/src/Services/Processor/Substrate/Codec/Encoder.php
+++ b/src/Services/Processor/Substrate/Codec/Encoder.php
@@ -60,8 +60,30 @@ class Encoder
     ];
 
     protected static array $overrideCallIndex = [
-        'MultiTokens.accept_collection_transfer' => [40, 41],
+        'MatrixUtility.batch' => [57, 0],
+        'Balances.transfer' => [10, 0],
+        'Balances.transfer_keep_alive' => [10, 3],
+        'Balances.transfer_all' => [10, 4],
+        'MultiTokens.approve_collection' => [40, 15],
+        'MultiTokens.unapprove_collection' => [40, 16],
+        'MultiTokens.approve_token' => [40, 17],
+        'MultiTokens.unapprove_token' => [40, 18],
+        'MultiTokens.batch_set_attribute' => [40, 14],
+        'MultiTokens.batch_transfer' => [40, 12],
+        'MultiTokens.transfer' => [40, 6],
+        'MultiTokens.create_collection' => [40, 0],
+        'MultiTokens.destroy_collection' => [40, 1],
+        'MultiTokens.mutate_collection' => [40, 2],
+        'MultiTokens.mutate_token' => [40, 3],
+        'MultiTokens.mint' => [40, 4],
+        'MultiTokens.batch_mint' => [40, 13],
+        'MultiTokens.burn' => [40, 5],
+        'MultiTokens.freeze' => [40, 7],
+        'MultiTokens.thaw' => [40, 8],
         'MultiTokens.set_attribute' => [40, 9],
+        'MultiTokens.remove_attribute' => [40, 10],
+        'MultiTokens.remove_all_attributes' => [40, 11],
+        'MultiTokens.accept_collection_transfer' => [40, 41],
     ];
 
     public function __construct(public ScaleInstance $scaleInstance)

--- a/src/Services/Processor/Substrate/Codec/Encoder.php
+++ b/src/Services/Processor/Substrate/Codec/Encoder.php
@@ -61,6 +61,7 @@ class Encoder
 
     protected static array $overrideCallIndex = [
         'MultiTokens.accept_collection_transfer' => [40, 41],
+        'MultiTokens.set_attribute' => [40, 9],
     ];
 
     public function __construct(public ScaleInstance $scaleInstance)

--- a/tests/Unit/EncodingTest.php
+++ b/tests/Unit/EncodingTest.php
@@ -94,7 +94,7 @@ class EncodingTest extends TestCase
             value: '3256489678678963378387378312'
         ));
 
-        $callIndex = $this->codec->encoder()->getCallIndex('Balances.transfer', true);
+        $callIndex = $this->codec->encoder()->getCallIndex('Balances.transfer_keep_alive', true);
         $this->assertEquals(
             "0x{$callIndex}0052e3c0eb993523286d19954c7e3ada6f791fa3f32764e44b9c1df0c2723bc15e238860bfb2b3660b3783b4850a",
             $data
@@ -135,7 +135,7 @@ class EncodingTest extends TestCase
 
         $callIndex = $this->codec->encoder()->getCallIndex('MatrixUtility.batch', true);
         $this->assertEquals(
-            "0x{$callIndex}080a030052e3c0eb993523286d19954c7e3ada6f791fa3f32764e44b9c1df0c2723bc15e040a070052e3c0eb993523286d19954c7e3ada6f791fa3f32764e44b9c1df0c2723bc15e0801",
+            "0x{$callIndex}080a030052e3c0eb993523286d19954c7e3ada6f791fa3f32764e44b9c1df0c2723bc15e040a000052e3c0eb993523286d19954c7e3ada6f791fa3f32764e44b9c1df0c2723bc15e0801",
             $data
         );
     }

--- a/tests/Unit/EncodingTest.php
+++ b/tests/Unit/EncodingTest.php
@@ -135,7 +135,7 @@ class EncodingTest extends TestCase
 
         $callIndex = $this->codec->encoder()->getCallIndex('MatrixUtility.batch', true);
         $this->assertEquals(
-            "0x{$callIndex}080a030052e3c0eb993523286d19954c7e3ada6f791fa3f32764e44b9c1df0c2723bc15e040a000052e3c0eb993523286d19954c7e3ada6f791fa3f32764e44b9c1df0c2723bc15e0801",
+            "0x{$callIndex}080a030052e3c0eb993523286d19954c7e3ada6f791fa3f32764e44b9c1df0c2723bc15e040a030052e3c0eb993523286d19954c7e3ada6f791fa3f32764e44b9c1df0c2723bc15e0801",
             $data
         );
     }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the `set_attribute` call index in the `Encoder` class by adding it to the `$overrideCallIndex` array with appropriate values.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Encoder.php</strong><dd><code>Fix `set_attribute` call index in Encoder class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Codec/Encoder.php

<li>Added <code>MultiTokens.set_attribute</code> to the <code>$overrideCallIndex</code> array with <br>values [40, 9].<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/208/files#diff-9cf4c9f5fbba52860e055d9fd9d792ee1341497b92819d63b7bb327e9459def4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

