### PR TITLE
[PLA-1904] Fix GetTokens query pagination

### DIFF
--- a/src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokensQuery.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokensQuery.php
@@ -73,7 +73,7 @@ class GetTokensQuery extends Query implements PlatformGraphQlQuery
         }
 
         return Token::loadSelectFields($resolveInfo, $this->name)
-            ->addSelect(DB::raw('CONCAT(collection_id,token_chain_id) AS identifier'))
+            ->addSelect(DB::raw('CONCAT(collection_id,id) AS identifier'))
             ->when($collectionId = Arr::get($args, 'collectionId'), fn ($query) => $query->whereHas(
                 'collection',
                 fn ($query) => $query->where('collection_chain_id', $collectionId)

--- a/src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokensQuery.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokensQuery.php
@@ -13,6 +13,7 @@ use Enjin\Platform\Models\Token;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class GetTokensQuery extends Query implements PlatformGraphQlQuery
@@ -72,11 +73,12 @@ class GetTokensQuery extends Query implements PlatformGraphQlQuery
         }
 
         return Token::loadSelectFields($resolveInfo, $this->name)
+            ->addSelect(DB::raw('CONCAT(collection_id,token_chain_id) AS identifier'))
             ->when($collectionId = Arr::get($args, 'collectionId'), fn ($query) => $query->whereHas(
                 'collection',
                 fn ($query) => $query->where('collection_chain_id', $collectionId)
             ))
             ->when(Arr::get($args, 'tokenIds'), fn ($query) => $query->whereIn('token_chain_id', $args['tokenIds']))
-            ->cursorPaginateWithTotalDesc('collection_id', $args['first']);
+            ->cursorPaginateWithTotalDesc('identifier', $args['first']);
     }
 }

--- a/src/Models/Laravel/Token.php
+++ b/src/Models/Laravel/Token.php
@@ -189,7 +189,11 @@ class Token extends BaseModel
 
     private function fetchUriAttribute($model)
     {
-        return $model->load('attributes')->getRelation('attributes')
+        if (!$model->relationLoaded('attributes')) {
+            $model->load('attributes');
+        }
+
+        return $model->getRelation('attributes')
             ->filter(fn ($attribute) => $attribute->key == 'uri')
             ->first();
     }

--- a/src/Models/Laravel/Traits/EagerLoadSelectFields.php
+++ b/src/Models/Laravel/Traits/EagerLoadSelectFields.php
@@ -155,7 +155,7 @@ trait EagerLoadSelectFields
 
         $relations = array_filter([
             isset($fields['nonFungible']) ? 'collection' : null,
-            ...(isset($fields['metadata']) ? ['attributes','collection'] : []),
+            ...(isset($fields['metadata']) ? ['attributes', 'collection'] : []),
             $hasBeneficiary ? 'royaltyBeneficiary' : null,
             ...TokenType::getRelationFields($fieldKeys),
         ]);

--- a/src/Models/Laravel/Traits/EagerLoadSelectFields.php
+++ b/src/Models/Laravel/Traits/EagerLoadSelectFields.php
@@ -155,11 +155,11 @@ trait EagerLoadSelectFields
 
         $relations = array_filter([
             isset($fields['nonFungible']) ? 'collection' : null,
-            isset($fields['metadata']) ? 'attributes' : null,
+            ...(isset($fields['metadata']) ? ['attributes','collection'] : []),
             $hasBeneficiary ? 'royaltyBeneficiary' : null,
             ...TokenType::getRelationFields($fieldKeys),
         ]);
-        foreach ($relations as $relation) {
+        foreach (array_unique($relations) as $relation) {
             if ($relation == 'accounts') {
                 $withCount[] = $relation;
             }

--- a/tests/Feature/GraphQL/Queries/GetTokensTest.php
+++ b/tests/Feature/GraphQL/Queries/GetTokensTest.php
@@ -16,6 +16,7 @@ use Enjin\Platform\Services\Token\Encoders\Integer;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as CollectionSupport;
 
 class GetTokensTest extends TestCaseGraphQL
@@ -139,6 +140,22 @@ class GetTokensTest extends TestCaseGraphQL
         ]);
 
         $this->assertTrue($response['totalCount'] >= 1);
+    }
+
+    public function test_it_can_fetch_tokens_next_page_from_a_collection(): void
+    {
+        $after = '';
+        $total = $this->tokens->count();
+        for ($i = 1; $i <= $total; $i++) {
+            $response = $this->graphql($this->method, [
+                'collectionId' => $this->collection->collection_chain_id,
+                'first' => 1,
+                'after' => $after,
+            ]);
+            $this->assertEquals(Arr::get($response, 'pageInfo.hasNextPage'), $i != $total);
+            $after = Arr::get($response, 'pageInfo.endCursor');
+        }
+
     }
 
     public function test_it_can_fetch_tokens_using_a_empty_list_for_token_ids(): void


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed cursor pagination issue by using a concatenated identifier in `GetTokensQuery`.
- Ensured `attributes` relation is loaded before accessing it in the `Token` model.
- Enhanced relation loading logic in `EagerLoadSelectFields` trait to include `collection` when `metadata` is present and avoid duplicates.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GetTokensQuery.php</strong><dd><code>Fix cursor pagination and add concatenated identifier</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokensQuery.php

<li>Added <code>DB</code> facade for raw SQL queries.<br> <li> Modified cursor pagination to use a concatenated identifier.<br> <li> Added a new select field for concatenated <code>collection_id</code> and <code>id</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/209/files#diff-08cb85fb70e65b2f3fe448c306de4bf039b5f6c59bee2e6a55180fde47607212">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Token.php</strong><dd><code>Ensure attributes relation is loaded before access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Models/Laravel/Token.php

<li>Ensured <code>attributes</code> relation is loaded before accessing it.<br> <li> Added conditional check for <code>attributes</code> relation.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/209/files#diff-c43aa5a65eba10e52488cbe7124d7bfed85857e528af165379a505edd28c5597">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EagerLoadSelectFields.php</strong><dd><code>Enhance relation loading logic for metadata fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Models/Laravel/Traits/EagerLoadSelectFields.php

<li>Added <code>collection</code> relation when <code>metadata</code> field is present.<br> <li> Used array_unique to avoid duplicate relations.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/209/files#diff-c27ee4ad4bad120faeb8bf21b26749f52237553adc2a347e1c28fe95014917f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

