### PR TITLE
[PLA-1914] Fixes teleport event

### DIFF
--- a/src/Events/Substrate/Balances/Teleport.php
+++ b/src/Events/Substrate/Balances/Teleport.php
@@ -12,22 +12,22 @@ class Teleport extends PlatformBroadcastEvent
     /**
      * Create a new event instance.
      */
-    public function __construct(mixed $event, ?Model $transaction = null)
+    public function __construct(Model $from, Model $to, string $amount, string $destination, ?Model $transaction = null)
     {
         parent::__construct();
 
         $this->broadcastData = [
             'idempotencyKey' => $transaction?->idempotency_key,
             'transactionHash' => $transaction?->transaction_chain_hash,
-            'from' => $from->address,
-            'to' => $to->address,
+            'from' => $from->public_key,
+            'to' => $to->public_key,
             'amount' => $amount,
             'destination' => $destination,
         ];
 
         $this->broadcastChannels = [
-            new Channel($from->address),
-            new Channel($to->address),
+            new Channel($from->public_key),
+            new Channel($to->public_key),
             new PlatformAppChannel(),
         ];
     }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Modified the `Teleport` event constructor to include `from`, `to`, `amount`, and `destination` parameters.
- Changed `from` and `to` properties from `address` to `public_key` in the broadcast data and channels.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Teleport.php</strong><dd><code>Fix and update Teleport event constructor and properties</code>&nbsp; </dd></summary>
<hr>

src/Events/Substrate/Balances/Teleport.php

<li>Modified constructor parameters to include <code>from</code>, <code>to</code>, <code>amount</code>, and <br><code>destination</code>.<br> <li> Changed <code>from</code> and <code>to</code> properties from <code>address</code> to <code>public_key</code>.<br> <li> Updated broadcast data and channels to use <code>public_key</code> instead of <br><code>address</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/213/files#diff-5f017e3d8121564a4ec2e0e9f4829c1faf19b3c3b3662cf120e69d384dfd4c48">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

