### PR TITLE
[PLA-1915] Fixes MintParams

### DIFF
--- a/src/GraphQL/Schemas/Primary/Substrate/Mutations/BatchMintMutation.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Mutations/BatchMintMutation.php
@@ -18,6 +18,7 @@ use Enjin\Platform\GraphQL\Types\Input\Substrate\Traits\HasSigningAccountField;
 use Enjin\Platform\GraphQL\Types\Input\Substrate\Traits\HasSimulateField;
 use Enjin\Platform\Interfaces\PlatformBlockchainTransaction;
 use Enjin\Platform\Interfaces\PlatformGraphQlMutation;
+use Enjin\Platform\Models\Substrate\MintParams;
 use Enjin\Platform\Models\Transaction;
 use Enjin\Platform\Rules\CheckTokenCount;
 use Enjin\Platform\Rules\IsCollectionOwner;
@@ -162,6 +163,10 @@ class BatchMintMutation extends Mutation implements PlatformBlockchainTransactio
                         ],
                         'params' => $recipient['params']->toEncodable(),
                     ]);
+
+                    if ($recipient['params'] instanceof MintParams) {
+                        return $data;
+                    }
 
                     return isRunningLatest() ? $data . '00000000' : $data;
                 }

--- a/src/Models/Substrate/MintParams.php
+++ b/src/Models/Substrate/MintParams.php
@@ -49,6 +49,7 @@ class MintParams
                 'tokenId' => gmp_init($this->tokenId),
                 'amount' => gmp_init($this->amount),
                 'unitPrice' => $this->unitPrice !== null ? gmp_init($this->unitPrice) : null,
+                'depositor' => null,
             ],
         ];
     }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added import for `MintParams` in `BatchMintMutation.php`.
- Added a condition to check if `params` is an instance of `MintParams` in `BatchMintMutation.php`.
- Added `depositor` field to the `toEncodable` method in `MintParams.php`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BatchMintMutation.php</strong><dd><code>Fix and enhance minting logic in BatchMintMutation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Substrate/Mutations/BatchMintMutation.php

<li>Added import for <code>MintParams</code>.<br> <li> Added condition to check if <code>params</code> is an instance of <code>MintParams</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/214/files#diff-3316a6892fe09365b961b443e48d3d05fe572745e995d57d4ac36d1c0c5469fd">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MintParams.php</strong><dd><code>Add depositor field to MintParams encoding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Models/Substrate/MintParams.php

- Added `depositor` field to the `toEncodable` method.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/214/files#diff-4376cf708c8bf3e9be300c5ea0939e999bc3f2d2e7bb917605ccce7c02423e72">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

