### PR TITLE
[PLA-1931] Fix checking for running latest version

### DIFF
--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -33,7 +33,7 @@ if (!function_exists('isRunningLatest')) {
      */
     function isRunningLatest(): bool
     {
-        return networkConfig('spec-version') == 1010;
+        return networkConfig('spec-version') >= 1010;
     }
 }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the `isRunningLatest` function to correctly determine if the network is running the latest version by checking if the `spec-version` is greater than or equal to 1010.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.php</strong><dd><code>Fix version check logic in `isRunningLatest` function</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Support/helpers.php

<li>Modified the <code>isRunningLatest</code> function to check if the <code>spec-version</code> is <br>greater than or equal to 1010 instead of strictly equal.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/222/files#diff-3e5775295c528f7b783a114f48e742f114e2d57204570c904c4b304b62f16754">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

