### PR TITLE
[PLA-1948] Tweak GetTokens query pagination for scopes.

### DIFF
--- a/src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokenQuery.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokenQuery.php
@@ -70,7 +70,7 @@ class GetTokenQuery extends Query implements PlatformGraphQlQuery
     }
 
     /**
-     * Get the validatio rules.
+     * Get the validator rules.
      */
     protected function rules(array $args = []): array
     {

--- a/src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokensQuery.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokensQuery.php
@@ -73,12 +73,11 @@ class GetTokensQuery extends Query implements PlatformGraphQlQuery
         }
 
         return Token::loadSelectFields($resolveInfo, $this->name)
-            ->addSelect(DB::raw('CONCAT(collection_id,id) AS identifier'))
             ->when($collectionId = Arr::get($args, 'collectionId'), fn ($query) => $query->whereHas(
                 'collection',
                 fn ($query) => $query->where('collection_chain_id', $collectionId)
             ))
             ->when(Arr::get($args, 'tokenIds'), fn ($query) => $query->whereIn('token_chain_id', $args['tokenIds']))
-            ->cursorPaginateWithTotalDesc('identifier', $args['first']);
+            ->cursorPaginateWithTotalDesc('id', $args['first']);
     }
 }

--- a/src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokensQuery.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokensQuery.php
@@ -13,7 +13,6 @@ use Enjin\Platform\Models\Token;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class GetTokensQuery extends Query implements PlatformGraphQlQuery


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `GetTokensQuery` to change the pagination logic by using 'id' instead of a concatenated 'identifier'.
- Removed unnecessary concatenation of 'collection_id' and 'id' for the identifier in the query.
- Fixed a typo in a comment within the `GetTokenQuery` file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GetTokenQuery.php</strong><dd><code>Fix typo in comment for validator rules method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokenQuery.php

- Corrected a typo in a comment from "validatio" to "validator".



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/224/files#diff-cbaaa8e3b1e5a0dbf4a1158779250886b868dbdfda1fb78f53bda96edefc3ac7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GetTokensQuery.php</strong><dd><code>Update pagination and identifier logic in GetTokensQuery</code>&nbsp; </dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokensQuery.php

<li>Removed concatenation of 'collection_id' and 'id' for identifier.<br> <li> Changed pagination to use 'id' instead of 'identifier'.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/224/files#diff-08cb85fb70e65b2f3fe448c306de4bf039b5f6c59bee2e6a55180fde47607212">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

