### PR TITLE
[PLA-1948] Add table name to select.

### DIFF
--- a/src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokensQuery.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokensQuery.php
@@ -73,7 +73,7 @@ class GetTokensQuery extends Query implements PlatformGraphQlQuery
         }
 
         return Token::loadSelectFields($resolveInfo, $this->name)
-            ->addSelect(DB::raw('CONCAT(collection_id,id) AS identifier'))
+            ->addSelect(DB::raw('CONCAT(tokens.collection_id,tokens.id) AS identifier'))
             ->when($collectionId = Arr::get($args, 'collectionId'), fn ($query) => $query->whereHas(
                 'collection',
                 fn ($query) => $query->where('collection_chain_id', $collectionId)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in the SQL query by adding table names to the `CONCAT` function in the `GetTokensQuery` class.
- Ensured that `collection_id` and `id` are correctly referenced with the `tokens` table name to avoid ambiguity.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GetTokensQuery.php</strong><dd><code>Add table name to SQL select statement for identifier</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Substrate/Queries/GetTokensQuery.php

<li>Modified the SQL query to include table names in the <code>CONCAT</code> function.<br> <li> Ensured that <code>collection_id</code> and <code>id</code> are prefixed with <code>tokens</code> table name.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/226/files#diff-08cb85fb70e65b2f3fe448c306de4bf039b5f6c59bee2e6a55180fde47607212">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

