### PR TITLE
[PLA-1956] Updates RetryTransaction to remove public key if equal to wallet daemon

### DIFF
--- a/src/GraphQL/Schemas/Primary/Substrate/Mutations/RetryTransactionsMutation.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Mutations/RetryTransactionsMutation.php
@@ -7,7 +7,7 @@ use Enjin\Platform\Enums\Global\TransactionState;
 use Enjin\Platform\GraphQL\Base\Mutation;
 use Enjin\Platform\GraphQL\Schemas\Primary\Substrate\Traits\InPrimarySubstrateSchema;
 use Enjin\Platform\Interfaces\PlatformGraphQlMutation;
-use Enjin\Platform\Models\Laravel\Transaction;
+use Enjin\Platform\Models\Transaction;
 use Enjin\Platform\Rules\MaxBigInt;
 use Enjin\Platform\Rules\MinBigInt;
 use Enjin\Platform\Support\Account;
@@ -72,7 +72,7 @@ class RetryTransactionsMutation extends Mutation implements PlatformGraphQlMutat
                 ? Transaction::whereIn('id', $ids)->get()
                 : Transaction::whereIn('idempotency_key', Arr::get($args, 'idempotencyKeys'))->get();
 
-            $txs->each(function (Transaction $tx): void {
+            $txs->each(function ($tx): void {
                 $tx->update([
                     'state' => TransactionState::PENDING->name,
                     'transaction_chain_hash' => null,

--- a/src/GraphQL/Schemas/Primary/Substrate/Mutations/RetryTransactionsMutation.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Mutations/RetryTransactionsMutation.php
@@ -7,7 +7,7 @@ use Enjin\Platform\Enums\Global\TransactionState;
 use Enjin\Platform\GraphQL\Base\Mutation;
 use Enjin\Platform\GraphQL\Schemas\Primary\Substrate\Traits\InPrimarySubstrateSchema;
 use Enjin\Platform\Interfaces\PlatformGraphQlMutation;
-use Enjin\Platform\Models\Transaction;
+use Enjin\Platform\Models\Laravel\Transaction;
 use Enjin\Platform\Rules\MaxBigInt;
 use Enjin\Platform\Rules\MinBigInt;
 use Enjin\Platform\Support\Account;
@@ -79,7 +79,9 @@ class RetryTransactionsMutation extends Mutation implements PlatformGraphQlMutat
                     'wallet_public_key' => $tx->wallet_public_key === Account::daemonPublicKey() ? null : $tx->wallet_public_key,
                 ]);
             });
-        }, 2);
+
+            return true;
+        });
     }
 
     /**

--- a/src/GraphQL/Schemas/Primary/Substrate/Mutations/RetryTransactionsMutation.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Mutations/RetryTransactionsMutation.php
@@ -72,7 +72,7 @@ class RetryTransactionsMutation extends Mutation implements PlatformGraphQlMutat
                 ? Transaction::whereIn('id', $ids)->get()
                 : Transaction::whereIn('idempotency_key', Arr::get($args, 'idempotencyKeys'))->get();
 
-            $txs->each(function (Transaction $tx) {
+            $txs->each(function (Transaction $tx): void {
                 $tx->update([
                     'state' => TransactionState::PENDING->name,
                     'transaction_chain_hash' => null,


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the `RetryTransactionsMutation` to use Laravel's `DB::transaction` for safer database operations.
- Updated the logic to conditionally remove the wallet public key if it matches the daemon's public key.
- Changed the import path for the `Transaction` model to align with Laravel's structure.
- Improved transaction update logic by iterating over each transaction and applying updates.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RetryTransactionsMutation.php</strong><dd><code>Enhance transaction retry logic with conditional public key removal</code></dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Substrate/Mutations/RetryTransactionsMutation.php

<li>Changed import of <code>Transaction</code> model to use Laravel namespace.<br> <li> Added use of <code>DB::transaction</code> for database operations.<br> <li> Updated transaction state and chain hash, and conditionally removed <br>wallet public key.<br> <li> Utilized <code>Account::daemonPublicKey()</code> for comparison.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/227/files#diff-9979283e18419d74f568ccb1094ca1035a258f3efea231907846324f5ff84a9f">+17/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

