### PR TITLE
[PLA-1966] Add network to GetPendingEvents

### DIFF
--- a/database/migrations/2024_08_27_083621_add_network_to_pending_events_table.php
+++ b/database/migrations/2024_08_27_083621_add_network_to_pending_events_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pending_events', function (Blueprint $table) {
+            $table->string('network')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pending_events', function (Blueprint $table) {
+            $table->dropColumn('network');
+        });
+    }
+};

--- a/lang/en/query.php
+++ b/lang/en/query.php
@@ -13,6 +13,7 @@ return [
     'get_collections.description' => 'Get an array of collections optionally filtered by collection IDs.',
     'get_pending_events.args.acknowledgeEvents' => 'Automatically acknowledge all returned events (defaults to false).',
     'get_pending_events.args.channelFilter' => 'Filter the events by channel.',
+    'get_pending_events.args.names' => 'Filter by event names.',
     'get_pending_events.description' => 'Get a list of events that were broadcast but not yet acknowledged.',
     'get_pending_wallets.description' => 'Get an array of wallet accounts which have yet to be verified.',
     'get_token.args.collectionId' => 'The token collection ID.',

--- a/lang/en/type.php
+++ b/lang/en/type.php
@@ -75,6 +75,7 @@ return [
     'pending_event.field.name' => 'The name of the event.',
     'pending_event.field.sent' => 'The timestamp when the event was sent.',
     'pending_event.field.uuid' => 'The UUID of the event.',
+    'pending_event.field.network' => 'The blockchain network.',
     'royalty.description' => 'Royalty settings.',
     'string_filter_input.description' => 'A string filter.',
     'string_filter_input.filter.description' => 'The term to filter to.',

--- a/src/CoreServiceProvider.php
+++ b/src/CoreServiceProvider.php
@@ -68,6 +68,7 @@ class CoreServiceProvider extends PackageServiceProvider
             ->hasMigration('modify_indexes')
             ->hasMigration('add_pending_transfer_collections_table')
             ->hasMigration('alter_attributes_table')
+            ->hasMigration('add_network_to_pending_events_table')
             ->hasRoute('enjin-platform')
             ->hasCommand(Sync::class)
             ->hasCommand(Ingest::class)

--- a/src/Events/PlatformBroadcastEvent.php
+++ b/src/Events/PlatformBroadcastEvent.php
@@ -122,14 +122,16 @@ abstract class PlatformBroadcastEvent implements ShouldBroadcast
      */
     protected function cacheEvent(): void
     {
-        $pendingEvent = PendingEvent::create([
-            'uuid' => $this->uuid,
-            'name' => $this->broadcastAs(),
-            'sent' => now()->toIso8601String(),
-            'channels' => collect($this->broadcastChannels)->pluck('name')->toJson(),
-            'data' => json_encode($this->broadcastData),
-            'network' => network(),
-        ]);
+        $pendingEvent = PendingEvent::updateOrCreate(
+            ['uuid' => $this->uuid],
+            [
+                'name' => $this->broadcastAs(),
+                'sent' => now()->toIso8601String(),
+                'channels' => collect($this->broadcastChannels)->pluck('name')->toJson(),
+                'data' => json_encode($this->broadcastData),
+                'network' => network(),
+            ]
+        );
 
         PlatformEventCached::dispatch($pendingEvent);
     }

--- a/src/Events/PlatformBroadcastEvent.php
+++ b/src/Events/PlatformBroadcastEvent.php
@@ -112,6 +112,11 @@ abstract class PlatformBroadcastEvent implements ShouldBroadcast
         return broadcast($event);
     }
 
+    public function getUuid()
+    {
+        return $this->uuid;
+    }
+
     /**
      * Store the event in the database.
      */

--- a/src/Events/PlatformBroadcastEvent.php
+++ b/src/Events/PlatformBroadcastEvent.php
@@ -123,6 +123,7 @@ abstract class PlatformBroadcastEvent implements ShouldBroadcast
             'sent' => now()->toIso8601String(),
             'channels' => collect($this->broadcastChannels)->pluck('name')->toJson(),
             'data' => json_encode($this->broadcastData),
+            'network' => network(),
         ]);
 
         PlatformEventCached::dispatch($pendingEvent);

--- a/src/GraphQL/Types/Global/PendingEventType.php
+++ b/src/GraphQL/Types/Global/PendingEventType.php
@@ -47,6 +47,11 @@ class PendingEventType extends GraphQLType implements PlatformGraphQlType
                 'type' => GraphQL::type('String!'),
                 'description' => __('enjin-platform::type.pending_event.field.sent'),
             ],
+            'network' => [
+                'type' => GraphQL::type('String'),
+                'description' => __('enjin-platform::type.pending_event.field.network'),
+                'resolve' => fn ($event) => $event->network ?? network()->value,
+            ],
             'channels' => [
                 'type' => GraphQL::type('[String]'),
                 'description' => __('enjin-platform::type.pending_event.field.channels'),

--- a/src/Models/Laravel/PendingEvent.php
+++ b/src/Models/Laravel/PendingEvent.php
@@ -40,6 +40,7 @@ class PendingEvent extends BaseModel
         'sent',
         'channels',
         'data',
+        'network',
     ];
 
     /**

--- a/tests/Feature/GraphQL/Queries/GetPendingEventsTest.php
+++ b/tests/Feature/GraphQL/Queries/GetPendingEventsTest.php
@@ -6,6 +6,7 @@ use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Enjin\Platform\Enums\Global\FilterType;
 use Enjin\Platform\Events\Substrate\MultiTokens\CollectionCreated;
 use Enjin\Platform\Models\Collection;
+use Enjin\Platform\Models\PendingEvent;
 use Enjin\Platform\Services\Processor\Substrate\Codec\Polkadart\Events\MultiTokens\CollectionCreated as CollectionCreatedPolkadart;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
 
@@ -59,6 +60,13 @@ class GetPendingEventsTest extends TestCaseGraphQL
     {
         $response = $this->graphql($this->method);
         $this->assertNotEmpty($response['edges']);
+    }
+
+    public function test_it_can_fetch_filter_event_with_names(): void
+    {
+        $eventNames = PendingEvent::take(100)->get('name')->toArray();
+        $response = $this->graphql($this->method, ['names' => $eventNames]);
+        $this->assertEquals(count($eventNames), count($response['edges']));
     }
 
     public function test_it_can_acknowledge_pending_event(): void


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Added a `network` column to the `pending_events` table through a new migration.
- Enhanced the `GetPendingEventsQuery` to support filtering by event `names`.
- Updated the `PendingEvent` model and related GraphQL types to include the `network` field.
- Added a new test to ensure the `names` filter works correctly in fetching pending events.
- Updated language files to include descriptions for the new `network` field and `names` argument.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>2024_08_27_083621_add_network_to_pending_events_table.php</strong><dd><code>Add `network` column to `pending_events` table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

database/migrations/2024_08_27_083621_add_network_to_pending_events_table.php

<li>Added a new migration file to include a <code>network</code> column in the <br><code>pending_events</code> table.<br> <li> Defined <code>up</code> and <code>down</code> methods for adding and removing the <code>network</code> <br>column.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/229/files#diff-102fee2eebfc43ec6908abc3fe53b5488713713e3bcd4b0687245210d2bc5433">+27/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>query.php</strong><dd><code>Add `names` argument to `get_pending_events` query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lang/en/query.php

<li>Added a new argument <code>names</code> for filtering events by name in the <br><code>get_pending_events</code> query.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/229/files#diff-87d818e26dafe74c44b2688d00d6c3e38bfe5bc0c6d9f79ef0e5a16f4fbdee8e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PlatformBroadcastEvent.php</strong><dd><code>Include `network` in `PendingEvent` creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Events/PlatformBroadcastEvent.php

- Added `network` field to the `PendingEvent` creation process.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/229/files#diff-d15ba1560215854d87567bb6abf311a6425581b2cf86f54b566dce97875d9172">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GetPendingEventsQuery.php</strong><dd><code>Support `names` filter in `GetPendingEventsQuery`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Queries/GetPendingEventsQuery.php

<li>Added support for filtering pending events by <code>names</code> in the GraphQL <br>query.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/229/files#diff-40544f2a2f4f57e146bbc13b03eb1547c2c940c397c19a9cc1ca7ebace2533e8">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PendingEventType.php</strong><dd><code>Add `network` field to `PendingEventType`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Types/Global/PendingEventType.php

- Added `network` field to the GraphQL `PendingEventType`.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/229/files#diff-00005b56ffab89426ef31051f327d7765fa722ef61e1a52c0541d5557cd35396">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PendingEvent.php</strong><dd><code>Make `network` fillable in `PendingEvent` model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Models/Laravel/PendingEvent.php

<li>Added <code>network</code> to the fillable attributes of the <code>PendingEvent</code> model.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/229/files#diff-6caeeb24a4bfce43f6cde67023a004281e1dcfac64a0f3247e24074ad19717f4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>type.php</strong><dd><code>Document `network` field in pending events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lang/en/type.php

- Added a description for the `network` field in pending events.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/229/files#diff-0663ed15566d07f6c546968e73ffec67317195fa879570a300af9238b91512b6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>CoreServiceProvider.php</strong><dd><code>Register migration for `network` column in `pending_events`</code></dd></summary>
<hr>

src/CoreServiceProvider.php

<li>Registered the new migration for adding the <code>network</code> column to <br><code>pending_events</code>.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/229/files#diff-7239ef674a3243e4c9895004a5f8ad86f9264922f450c554605b3a1c7fe02d62">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>GetPendingEventsTest.php</strong><dd><code>Test filtering pending events by `names`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Queries/GetPendingEventsTest.php

- Added a test to verify filtering of pending events by `names`.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/229/files#diff-b559d641dbf88c117367dd2297820baaee2859c420efb208dca0bc59f1b86931">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

