### PR TITLE
[PLA-1968] Prevent duplicate wallet public key

### DIFF
--- a/src/GraphQL/Schemas/Primary/Mutations/SetWalletAccountMutation.php
+++ b/src/GraphQL/Schemas/Primary/Mutations/SetWalletAccountMutation.php
@@ -116,7 +116,7 @@ class SetWalletAccountMutation extends Mutation implements PlatformGraphQlMutati
                 new ValidSubstrateAccount(),
                 function (string $attribute, mixed $value, Closure $fail): void {
                     if (Wallet::where('public_key', SS58Address::getPublicKey($value))
-                        ->withoutGlobalScope('tenant')->exists()
+                        ->withoutGlobalScopes()->exists()
                     ) {
                         $fail('validation.unique')->translate();
                     }

--- a/tests/Feature/GraphQL/Mutations/SetWalletAccountTest.php
+++ b/tests/Feature/GraphQL/Mutations/SetWalletAccountTest.php
@@ -162,8 +162,8 @@ class SetWalletAccountTest extends TestCaseGraphQL
             'account' => SS58Address::encode($publicKey),
         ], true);
 
-        $this->assertStringContainsString(
-            'The account has already been taken.',
+        $this->assertArraySubset(
+            ['account' => ['The account has already been taken.']],
             $response['error']
         );
     }


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a new validation rule in `SetWalletAccountMutation` to prevent duplicate wallet public keys by checking existing entries in the database.
- Updated the test `test_it_will_fail_with_duplicated_address` to assert the error response as an array subset, ensuring the correct error message is returned for duplicate accounts.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SetWalletAccountMutation.php</strong><dd><code>Add validation to prevent duplicate wallet public keys</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Mutations/SetWalletAccountMutation.php

<li>Removed the rule for <code>account</code> validation from the existing array.<br> <li> Added a new <code>rules</code> method to define validation rules for <code>account</code>.<br> <li> Implemented a closure to check for duplicate public keys in the <code>rules</code> <br>method.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/230/files#diff-b054f8bc8d2a14bdf8d05e462b14dc9ca8a75bf3f4900cabd786eeb69a2753d1">+21/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SetWalletAccountTest.php</strong><dd><code>Update test to validate duplicate account error handling</code>&nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/SetWalletAccountTest.php

<li>Modified test assertion to check for array subset instead of string.<br> <li> Ensured the test checks for duplicate account error message.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/230/files#diff-501bc6f4578bde7ab9c6c5ac4f301e19049d1d777d4f3a2f4154546d6a0cafb5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

