### PR TITLE
[PLA-1974] Add return null

### DIFF
--- a/src/Services/Processor/Substrate/DecoderService.php
+++ b/src/Services/Processor/Substrate/DecoderService.php
@@ -51,6 +51,8 @@ class DecoderService
         } catch (Throwable $e) {
             Log::error("Failed to serialize: {$e->getMessage()}");
         }
+
+        return null;
     }
 
     protected function polkadartSerialize($type, $data): array


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Added a `return null` statement in the `safeSerialize` method to handle exceptions gracefully by returning `null` when serialization fails.
- This change ensures that the method has a consistent return type and improves error handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DecoderService.php</strong><dd><code>Add return null for exception handling in serialization</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/DecoderService.php

<li>Added a return statement to handle cases where serialization fails.<br> <li> Ensures the function returns <code>null</code> if an exception is caught.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/234/files#diff-ee2e97bb5c16175368f7ae78ff061939e97dde23557e6ab132203ef05526815a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

