### PR TITLE
Lower decoder retry to 3

### DIFF
--- a/src/Services/Processor/Substrate/BlockProcessor.php
+++ b/src/Services/Processor/Substrate/BlockProcessor.php
@@ -268,7 +268,7 @@ class BlockProcessor
     {
         $try = 0;
 
-        while (empty($result = call_user_func($f)) && $try < 5) {
+        while (empty($result = call_user_func($f)) && $try < 3) {
             usleep($sleep = 1000000 * $try ** 2);
             $this->warn(sprintf('Retrying to fetch %s for block #%s in %s seconds', $action, $blockNumber, $sleep / 1000000));
             $try++;


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Reduced the retry limit in the `runOrWaitIfEmpty` function from 5 to 3 to potentially improve performance and reduce wait times.
- Adjusted the retry mechanism for fetching block data, which may affect how the system handles empty results.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BlockProcessor.php</strong><dd><code>Lower retry limit for block fetching mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/BlockProcessor.php

<li>Reduced the retry limit from 5 to 3 in the <code>runOrWaitIfEmpty</code> function.<br> <li> Adjusted the retry mechanism for fetching block data.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/236/files#diff-5e9d1640ff87e611a83e41e14038785fc69b77343a16a046571f964b5f3db954">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

