### PR TITLE
[PLA-1979] Throw exception on invalid encoded data

### DIFF
--- a/src/Services/Processor/Substrate/Codec/Encoder.php
+++ b/src/Services/Processor/Substrate/Codec/Encoder.php
@@ -264,7 +264,7 @@ class Encoder
         ]);
 
         $hex = HexConverter::prefix($encoded);
-        if (preg_match('/^0x[a-fA-F0-9]+$/', $hex) >= 1) {
+        if (Hex::isHexEncoded($hex)) {
             return $hex;
         }
 

--- a/src/Services/Processor/Substrate/Codec/Encoder.php
+++ b/src/Services/Processor/Substrate/Codec/Encoder.php
@@ -268,7 +268,7 @@ class Encoder
             return $hex;
         }
 
-        throw new PlatformException('Invalid encoded data: '.$hex);
+        throw new PlatformException('Invalid encoded data: ' . $hex);
     }
 
     public function systemAccountStorageKey(string $publicKey): string

--- a/src/Services/Processor/Substrate/Codec/Encoder.php
+++ b/src/Services/Processor/Substrate/Codec/Encoder.php
@@ -264,7 +264,7 @@ class Encoder
         ]);
 
         $hex = HexConverter::prefix($encoded);
-        if (preg_match('/^0x[a-fA-F0-9]*$/', $hex) >= 1) {
+        if (preg_match('/^0x[a-fA-F0-9]+$/', $hex) >= 1) {
             return $hex;
         }
 

--- a/src/Services/Processor/Substrate/Codec/Encoder.php
+++ b/src/Services/Processor/Substrate/Codec/Encoder.php
@@ -9,6 +9,7 @@ use Enjin\BlockchainTools\HexConverter;
 use Enjin\Platform\Clients\Implementations\SubstrateWebsocket;
 use Enjin\Platform\Enums\Global\PlatformCache;
 use Enjin\Platform\Enums\Substrate\StorageType;
+use Enjin\Platform\Exceptions\PlatformException;
 use Enjin\Platform\Models\Substrate\RoyaltyPolicyParams;
 use Enjin\Platform\Support\Blake2;
 use Enjin\Platform\Support\Hex;
@@ -262,7 +263,12 @@ class Encoder
             ...$params,
         ]);
 
-        return HexConverter::prefix($encoded);
+        $hex = HexConverter::prefix($encoded);
+        if (preg_match('/^0x[a-fA-F0-9]*$/', $hex) >= 1) {
+            return $hex;
+        }
+
+        throw new PlatformException('Invalid encoded data: '.$hex);
     }
 
     public function systemAccountStorageKey(string $publicKey): string


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added a validation step to ensure that encoded data is in the correct hexadecimal format.
- Throws a `PlatformException` if the encoded data does not match the expected format, improving error handling.
- This change prevents invalid encoded data from being processed further in the system.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Encoder.php</strong><dd><code>Add validation and exception for invalid encoded data</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Codec/Encoder.php

<li>Added import for <code>PlatformException</code>.<br> <li> Implemented validation for encoded data format.<br> <li> Throws <code>PlatformException</code> on invalid encoded data.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/237/files#diff-9cf4c9f5fbba52860e055d9fd9d792ee1341497b92819d63b7bb327e9459def4">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

