### PR TITLE
[PLA-1982] Upgrade runtime & specs for mainnet

### DIFF
--- a/config/enjin-platform.php
+++ b/config/enjin-platform.php
@@ -102,8 +102,8 @@ return [
                     'node' => env('SUBSTRATE_ENJIN_RPC', 'wss://rpc.matrix.blockchain.enjin.io'),
                     'ss58-prefix' => env('SUBSTRATE_ENJIN_SS58_PREFIX', 1110),
                     'genesis-hash' => env('SUBSTRATE_ENJIN_GENESIS_HASH', '0x3af4ff48ec76d2efc8476730f423ac07e25ad48f5f4c9dc39c778b164d808615'),
-                    'spec-version' => env('SUBSTRATE_ENJIN_SPEC_VERSION', 1006),
-                    'transaction-version' => env('SUBSTRATE_ENJIN_TRANSACTION_VERSION', 7),
+                    'spec-version' => env('SUBSTRATE_ENJIN_SPEC_VERSION', 1012),
+                    'transaction-version' => env('SUBSTRATE_ENJIN_TRANSACTION_VERSION', 10),
                 ],
                 'enjin' => $enjin,
                 NetworkType::CANARY_MATRIX->value => $canary = [
@@ -138,8 +138,8 @@ return [
                     'node' => env('SUBSTRATE_ENJIN_RELAY_RPC', 'wss://rpc.relay.blockchain.enjin.io'),
                     'ss58-prefix' => env('SUBSTRATE_ENJIN_RELAY_SS58_PREFIX', 2135),
                     'genesis-hash' => env('SUBSTRATE_ENJIN_RELAY_GENESIS_HASH', '0xd8761d3c88f26dc12875c00d3165f7d67243d56fc85b4cf19937601a7916e5a9'),
-                    'spec-version' => env('SUBSTRATE_ENJIN_RELAY_SPEC_VERSION', 1026),
-                    'transaction-version' => env('SUBSTRATE_ENJIN_RELAY_TRANSACTION_VERSION', 7),
+                    'spec-version' => env('SUBSTRATE_ENJIN_RELAY_SPEC_VERSION', 1032),
+                    'transaction-version' => env('SUBSTRATE_ENJIN_RELAY_TRANSACTION_VERSION', 10),
                 ],
                 NetworkType::CANARY_RELAY->value => [
                     'chain-id' => 1,

--- a/config/enjin-runtime.php
+++ b/config/enjin-runtime.php
@@ -15,6 +15,7 @@ return [
         ['specVersion' => 1024, 'blockNumber' => 3232725, 'blockHash' => '0x8699393c07cee37eef6950f097b29b79da8d0c0ca8dfaea8ec8394879a998826'],
         ['specVersion' => 1025, 'blockNumber' => 3384038, 'blockHash' => '0x4b41e9fb20bf7e22ead24e10b4024c335c2d336be9be9bf6b2852df7deba454d'],
         ['specVersion' => 1026, 'blockNumber' => 3858176, 'blockHash' => '0xb2a6c804f699b777e7f6b2e7adbf78636c2143fa79426aaf1525f4e3c9c7f08c'],
+        ['specVersion' => 1032, 'blockNumber' => 6679470, 'blockHash' => '0x4a45e738c960959ec3d16f2d7dbda76d5d2410bd44b85734d5f6968c768c8a02'],
     ],
     NetworkType::CANARY_RELAY->value => [
         ['specVersion' => 100, 'blockNumber' => 0, 'blockHash' => '0x735d8773c63e74ff8490fee5751ac07e15bfe2b3b5263be4d683c48dbdfbcd15'],
@@ -47,6 +48,7 @@ return [
         ['specVersion' => 1004, 'blockNumber' => 1218749, 'blockHash' => '0x35ba9118db958657bf2c92c1f433111e66703812fd4fdce169027852bf9bfcd2'],
         ['specVersion' => 1005, 'blockNumber' => 1261794, 'blockHash' => '0xbba1eb93d850c142851ddce6161aecd6a6fe026392a8d478f1f04690b0e97d0f'],
         ['specVersion' => 1006, 'blockNumber' => 1728545, 'blockHash' => '0x24ec59a2831c65aefc8437270299e5e6764c68b4e76cdbc9dc4d2c0d8086b32d'],
+        ['specVersion' => 1012, 'blockNumber' => 2609693, 'blockHash' => '0x211403edc5f274431b89e56ee9bb7d22694cfc436673906e9b20121c07490c53'],
     ],
     NetworkType::CANARY_MATRIX->value => [
         ['specVersion' => 500, 'blockNumber' => 0, 'blockHash' => '0xa37725fd8943d2a524cb7ecc65da438f9fa644db78ba24dcd0003e2f95645e8f'],


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated the `spec-version` and `transaction-version` for `SUBSTRATE_ENJIN` to 1012 and 10, respectively.
- Updated the `spec-version` and `transaction-version` for `SUBSTRATE_ENJIN_RELAY` to 1032 and 10, respectively.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>enjin-platform.php</strong><dd><code>Update spec and transaction versions in configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/enjin-platform.php

<li>Updated <code>spec-version</code> and <code>transaction-version</code> for <code>SUBSTRATE_ENJIN</code>.<br> <li> Updated <code>spec-version</code> and <code>transaction-version</code> for <br><code>SUBSTRATE_ENJIN_RELAY</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/239/files#diff-e687a9c8af991f77587526ea6983e8c280929f8ccf6b989eb1eb83c0d8f4d220">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

