### PR TITLE
[PLA-1985] Allow update with same hash on UpdateTransaction

### DIFF
--- a/src/Rules/ImmutableTransaction.php
+++ b/src/Rules/ImmutableTransaction.php
@@ -22,8 +22,10 @@ class ImmutableTransaction implements DataAwareRule, ValidationRule
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (($id = $this->data['id']) && ($transaction = Transaction::find($id))) {
-            if (filled($value) && $transaction->{$this->column}) {
-                $fail('enjin-platform::mutation.update_transaction.error.hash_and_id_are_immutable')->translate();
+            if (filled($value) && $v = $transaction->{$this->column}) {
+                if ($value !== $v) {
+                    $fail('enjin-platform::mutation.update_transaction.error.hash_and_id_are_immutable')->translate();
+                }
             }
         }
     }

--- a/tests/Feature/GraphQL/Mutations/UpdateTransactionTest.php
+++ b/tests/Feature/GraphQL/Mutations/UpdateTransactionTest.php
@@ -383,7 +383,7 @@ class UpdateTransactionTest extends TestCaseGraphQL
 
         $response = $this->graphql($this->method, [
             'id' => $transaction->id,
-            'transactionId' => $transaction->transaction_chain_id,
+            'transactionId' => fake()->numerify('######-#'),
         ], true);
 
         $this->assertArraySubset([
@@ -399,7 +399,7 @@ class UpdateTransactionTest extends TestCaseGraphQL
 
         $response = $this->graphql($this->method, [
             'id' => $transaction->id,
-            'transactionHash' => $transaction->transaction_chain_hash,
+            'transactionHash' => HexConverter::prefix(fake()->sha256()),
         ], true);
 
         $this->assertArraySubset([


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed a bug in the `ImmutableTransaction` class where updates with the same hash were incorrectly failing.
- Added a condition to ensure that the validation only fails if the new hash value is different from the existing one.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ImmutableTransaction.php</strong><dd><code>Fix validation to allow updates with identical hash values</code></dd></summary>
<hr>

src/Rules/ImmutableTransaction.php

<li>Modified the validation logic to allow updates with the same hash.<br> <li> Added a condition to check if the new value is different before <br>failing.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/242/files#diff-60b3369ecdd74a8c3af1f518a86953c66a1ec6083411170bd5cfc949dd34d6a8">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

