### PR TITLE
[PLA-1986] Fixes storage parsing during migration

### DIFF
--- a/src/Services/Processor/Substrate/Codec/Decoder.php
+++ b/src/Services/Processor/Substrate/Codec/Decoder.php
@@ -13,6 +13,7 @@ use Enjin\Platform\Models\Substrate\MintParams;
 use Enjin\Platform\Models\Substrate\MintPolicyParams;
 use Enjin\Platform\Models\Substrate\RoyaltyPolicyParams;
 use Illuminate\Support\Arr;
+use PHPUnit\Exception;
 
 class Decoder
 {
@@ -192,7 +193,11 @@ class Decoder
 
     public function collectionStorageData(string $data): array
     {
-        $decoded = $this->codec->process(isRunningLatest() ? 'CollectionStorageDataV1010' : 'CollectionStorageData', new ScaleBytes($data));
+        try {
+            $decoded = $this->codec->process('CollectionStorageDataV1010', new ScaleBytes($data));
+        } catch (\Exception $e) {
+            $decoded = $this->codec->process('CollectionStorageData', new ScaleBytes($data));
+        }
 
         return [
             'owner' => ($owner = Arr::get($decoded, 'owner')) !== null ? HexConverter::prefix($owner) : null,
@@ -223,7 +228,11 @@ class Decoder
 
     public function tokenStorageData(string $data): array
     {
-        $decoded = $this->codec->process(isRunningLatest() ? 'TokenStorageDataV1010' : 'TokenStorageData', new ScaleBytes($data));
+        try {
+            $decoded = $this->codec->process('TokenStorageDataV1010', new ScaleBytes($data));
+        } catch (Exception $e) {
+            $decoded = $this->codec->process('TokenStorageData', new ScaleBytes($data));
+        }
 
         $cap = TokenMintCapType::tryFrom(collect(Arr::get($decoded, 'cap'))->keys()->first()) ?? TokenMintCapType::INFINITE;
         $capSupply = Arr::get($decoded, 'cap.Supply') ?? Arr::get($decoded, 'cap.CollapsingSupply');


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added `try-catch` blocks to the `collectionStorageData` and `tokenStorageData` methods to handle exceptions when processing data.
- Updated the processing logic to attempt decoding with `V1010` version first and fallback to the previous version if an exception occurs.
- Imported `PHPUnit\Exception` to manage exceptions effectively.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Decoder.php</strong><dd><code>Add exception handling to storage data processing methods</code></dd></summary>
<hr>

src/Services/Processor/Substrate/Codec/Decoder.php

<li>Added exception handling for <code>collectionStorageData</code> and <br><code>tokenStorageData</code> methods.<br> <li> Used <code>try-catch</code> blocks to handle potential exceptions during data <br>processing.<br> <li> Imported <code>PHPUnit\Exception</code> for exception handling.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/243/files#diff-77b812adae42ce68fa3dbfb9682abf9e9144dfeeaeac55b58898efbc66409979">+11/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

