### PR TITLE
Adds deprecationReason to keepAlive & TransferBalance

### DIFF
--- a/lang/en/deprecated.php
+++ b/lang/en/deprecated.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
-    'operator_transfer_token.args.keepAlive' => 'This flag has been removed from the blockchain and will be ignored.',
+    'operator_transfer_token.args.params.keepAlive' => 'This flag has been removed from the blockchain and will be ignored.',
+    'simple_transfer_token.args.params.keepAlive' => 'This flag has been removed from the blockchain and will be ignored.',
     'transfer_balance.description' => 'The extrinsic has been removed from the blockchain in favor of TransferKeepAlive and TransferAllowDeath',
 ];

--- a/lang/en/mutation.php
+++ b/lang/en/mutation.php
@@ -71,6 +71,8 @@ return [
     'mutate_collection.description' => 'Changes collection default values.',
     'mutate_token.description' => 'Changes token default values.',
     'operator_transfer_token.args.params' => 'The operator transfer params.',
+    'operator_transfer_token.args.params.keepAlive' => '(DEPRECATED) If true, the transaction will fail if the balance drops below the minimum requirement. Defaults to False.',
+    'simple_transfer_token.args.params.keepAlive' => '(DEPRECATED) If true, the transaction will fail if the balance drops below the minimum requirement. Defaults to False.',
     'operator_transfer_token.description' => "Transfer tokens as the operator of someone else's wallet. Operator transfers are transfers that you make using tokens from somebody else's wallet as the source. To make this type of transfer the source wallet owner must approve you for transferring their tokens.",
     'remove_all_attributes.args.attributeCount' => 'This is an advanced feature and is used to calculate the weight of the on-chain extrinsic. Putting a value in that isn\'t equal to the on-chain attribute count will lead to the transaction failing. When empty, the attribute count will be auto calculated from data stored in the local database.',
     'remove_all_attributes.args.collectionId' => 'The collection ID to remove attributes from.',

--- a/src/GraphQL/Schemas/Primary/Substrate/Mutations/TransferBalanceMutation.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Mutations/TransferBalanceMutation.php
@@ -47,7 +47,7 @@ class TransferBalanceMutation extends Mutation implements PlatformBlockchainTran
         return [
             'name' => 'TransferBalance',
             'description' => __('enjin-platform::mutation.transfer_balance.description'),
-            // TODO: 'deprecationReason' => __('enjin-platform::deprecated.transfer_balance.description'),
+            'deprecationReason' => __('enjin-platform::deprecated.transfer_balance.description'),
         ];
     }
 
@@ -100,8 +100,7 @@ class TransferBalanceMutation extends Mutation implements PlatformBlockchainTran
         WalletService $walletService
     ): mixed {
         $targetWallet = $walletService->firstOrStore(['account' => $args['recipient']]);
-        $method = $this->getMutationName() . ($args['keepAlive'] ? 'KeepAlive' : '');
-        $encodedData = $serializationService->encode($method, static::getEncodableParams(
+        $encodedData = $serializationService->encode($this->getMethodName(), static::getEncodableParams(
             recipientAccount: $targetWallet->public_key,
             value: $args['amount']
         ));
@@ -110,6 +109,11 @@ class TransferBalanceMutation extends Mutation implements PlatformBlockchainTran
             $this->storeTransaction($args, $encodedData),
             $resolveInfo
         );
+    }
+
+    public function getMethodName(): string
+    {
+        return 'TransferAllowDeath';
     }
 
     public static function getEncodableParams(...$params): array

--- a/src/GraphQL/Schemas/Primary/Substrate/Mutations/TransferBalanceMutation.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Mutations/TransferBalanceMutation.php
@@ -47,7 +47,7 @@ class TransferBalanceMutation extends Mutation implements PlatformBlockchainTran
         return [
             'name' => 'TransferBalance',
             'description' => __('enjin-platform::mutation.transfer_balance.description'),
-            'deprecationReason' => __('enjin-platform::deprecated.transfer_balance.description'),
+            // TODO: 'deprecationReason' => __('enjin-platform::deprecated.transfer_balance.description'),
         ];
     }
 

--- a/src/GraphQL/Types/Input/Substrate/OperatorTransferParamsInputType.php
+++ b/src/GraphQL/Types/Input/Substrate/OperatorTransferParamsInputType.php
@@ -43,7 +43,7 @@ class OperatorTransferParamsInputType extends InputType implements PlatformGraph
             'keepAlive' => [
                 'type' => GraphQL::type('Boolean'),
                 'description' => __('enjin-platform::mutation.operator_transfer_token.args.params.keepAlive'),
-                'deprecatedReason' => __('enjin-platform::deprecated.operator_transfer_token.args.params.keepAlive'),
+                // TODO: 'deprecationReason' => __('enjin-platform::deprecated.operator_transfer_token.args.params.keepAlive'),
                 'defaultValue' => false,
             ],
         ];

--- a/src/GraphQL/Types/Input/Substrate/OperatorTransferParamsInputType.php
+++ b/src/GraphQL/Types/Input/Substrate/OperatorTransferParamsInputType.php
@@ -43,7 +43,7 @@ class OperatorTransferParamsInputType extends InputType implements PlatformGraph
             'keepAlive' => [
                 'type' => GraphQL::type('Boolean'),
                 'description' => __('enjin-platform::mutation.operator_transfer_token.args.params.keepAlive'),
-                // TODO: 'deprecationReason' => __('enjin-platform::deprecated.operator_transfer_token.args.params.keepAlive'),
+                'deprecationReason' => __('enjin-platform::deprecated.operator_transfer_token.args.params.keepAlive'),
                 'defaultValue' => false,
             ],
         ];

--- a/src/GraphQL/Types/Input/Substrate/SimpleTransferParamsInputType.php
+++ b/src/GraphQL/Types/Input/Substrate/SimpleTransferParamsInputType.php
@@ -37,7 +37,8 @@ class SimpleTransferParamsInputType extends InputType implements PlatformGraphQl
             ],
             'keepAlive' => [
                 'type' => GraphQL::type('Boolean'),
-                'description' => __('enjin-platform::mutation.batch_set_attribute.args.keepAlive'),
+                'description' => __('enjin-platform::mutation.simple_transfer_token.args.params.keepAlive'),
+                // TODO: 'deprecationReason' => __('enjin-platform::deprecated.simple_transfer_token.args.params.keepAlive'),
                 'defaultValue' => false,
             ],
         ];

--- a/src/GraphQL/Types/Input/Substrate/SimpleTransferParamsInputType.php
+++ b/src/GraphQL/Types/Input/Substrate/SimpleTransferParamsInputType.php
@@ -38,7 +38,7 @@ class SimpleTransferParamsInputType extends InputType implements PlatformGraphQl
             'keepAlive' => [
                 'type' => GraphQL::type('Boolean'),
                 'description' => __('enjin-platform::mutation.simple_transfer_token.args.params.keepAlive'),
-                // TODO: 'deprecationReason' => __('enjin-platform::deprecated.simple_transfer_token.args.params.keepAlive'),
+                'deprecationReason' => __('enjin-platform::deprecated.simple_transfer_token.args.params.keepAlive'),
                 'defaultValue' => false,
             ],
         ];


### PR DESCRIPTION
### **PR Type**
enhancement, documentation


___

### **Description**
- Added deprecation messages for `keepAlive` parameter in `operator_transfer_token` and `simple_transfer_token` in language files.
- Commented out `deprecationReason` in GraphQL schema and input type files for `TransferBalance`, `OperatorTransferParams`, and `SimpleTransferParams`.
- Updated descriptions for `keepAlive` parameter in mutation files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deprecated.php</strong><dd><code>Add deprecation messages for transfer token parameters</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lang/en/deprecated.php

<li>Added deprecation message for <br><code>simple_transfer_token.args.params.keepAlive</code>.<br> <li> Updated deprecation message for <br><code>operator_transfer_token.args.params.keepAlive</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/251/files#diff-bbf378cf7f51651f9b15f009e7bf6a9d5bae71f258ab287d7ad097f38910cce1">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mutation.php</strong><dd><code>Document deprecation of keepAlive parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lang/en/mutation.php

<li>Added deprecation note for <code>keepAlive</code> parameter in <br><code>operator_transfer_token</code> and <code>simple_transfer_token</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/251/files#diff-4f781bb4f33dedd74b3c9d8f53e97e9bfcb9dff0dd4883bc2d3338fbec35ffe3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TransferBalanceMutation.php</strong><dd><code>Comment out deprecation reason for TransferBalance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Substrate/Mutations/TransferBalanceMutation.php

- Commented out `deprecationReason` for `TransferBalance`.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/251/files#diff-f6ac8fcfa1d14a2d9ac84df82c714f3a4014b2d5c91ac2434e5b9b6f6943106e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>OperatorTransferParamsInputType.php</strong><dd><code>Comment out deprecation reason for OperatorTransferParams</code></dd></summary>
<hr>

src/GraphQL/Types/Input/Substrate/OperatorTransferParamsInputType.php

- Commented out `deprecationReason` for `keepAlive` parameter.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/251/files#diff-d0358190d09918f815de37bf46f73948cccc6dea861dfc6aca8bb444c4318443">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SimpleTransferParamsInputType.php</strong><dd><code>Update and comment out deprecation for SimpleTransferParams</code></dd></summary>
<hr>

src/GraphQL/Types/Input/Substrate/SimpleTransferParamsInputType.php

<li>Updated description for <code>keepAlive</code> parameter.<br> <li> Commented out <code>deprecationReason</code> for <code>keepAlive</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/251/files#diff-c38f9fe0ef27186f2a32458d6e873e5c034c274c77cae53e622c5edd39071e15">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

