### PR TITLE
[PLA-2004] Forget customTypes when ingest starts

### DIFF
--- a/src/Services/Processor/Substrate/BlockProcessor.php
+++ b/src/Services/Processor/Substrate/BlockProcessor.php
@@ -140,6 +140,8 @@ class BlockProcessor
 
     public function ingest(): void
     {
+        Cache::forget(PlatformCache::CUSTOM_TYPES->key());
+
         $currentHeight = $this->latestBlock();
         $lastBlockSynced = $this->latestSyncedBlock();
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a call to `Cache::forget` for `PlatformCache::CUSTOM_TYPES` in the `ingest` method to ensure that custom types are forgotten when the ingest process starts.
- This change helps in maintaining the integrity of the cache by clearing outdated custom types before starting a new ingest process.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BlockProcessor.php</strong><dd><code>Clear custom types cache at the start of ingest process</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/BlockProcessor.php

<li>Added a call to <code>Cache::forget</code> to clear custom types cache.<br> <li> Ensures that custom types are forgotten when ingest starts.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/252/files#diff-5e9d1640ff87e611a83e41e14038785fc69b77343a16a046571f964b5f3db954">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

