### PR TITLE
[PLA-2014] Adds SubstrateHttpClient for fetching balance

### DIFF
--- a/src/Clients/Implementations/AsyncSocketClient.php
+++ b/src/Clients/Implementations/AsyncSocketClient.php
@@ -14,7 +14,7 @@ use JsonException;
 
 use function Amp\Websocket\Client\connect;
 
-class AsyncWebsocket
+class AsyncSocketClient
 {
     /**
      * The host name.

--- a/src/Clients/Implementations/DecoderHttpClient.php
+++ b/src/Clients/Implementations/DecoderHttpClient.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 
-class DecoderClient extends JsonHttpAbstract
+class DecoderHttpClient extends JsonHttpAbstract
 {
     /**
      * Get the http client instance.

--- a/src/Clients/Implementations/MetadataHttpClient.php
+++ b/src/Clients/Implementations/MetadataHttpClient.php
@@ -4,7 +4,7 @@ namespace Enjin\Platform\Clients\Implementations;
 
 use Enjin\Platform\Clients\Abstracts\CachedHttpAbstract;
 
-class MetadataClient extends CachedHttpAbstract
+class MetadataHttpClient extends CachedHttpAbstract
 {
     /**
      * Get the data from the given url.

--- a/src/Clients/Implementations/SubstrateHttpClient.php
+++ b/src/Clients/Implementations/SubstrateHttpClient.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Enjin\Platform\Clients\Implementations;
+
+use Arr;
+use Enjin\Platform\Clients\Abstracts\JsonHttpAbstract;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+
+class SubstrateHttpClient extends JsonHttpAbstract
+{
+    protected string $url;
+
+    /**
+     * Create a new http client instance.
+     */
+    public function __construct(?string $url = null)
+    {
+        $host = $url ?? currentMatrixUrl();
+
+        $this->url = str_replace('wss', 'https', $host);
+    }
+
+    /**
+     * @throws ConnectionException
+     * @throws RequestException
+     */
+    public function jsonRpc(string $method, array $params): mixed
+    {
+        $result = $this->getClient()->post($this->url, [
+            'jsonrpc' => '2.0',
+            'method' => $method,
+            'params' => $params,
+            'id' => mt_rand(1, 999999999),
+        ]);
+
+        return Arr::get($this->getResponse($result), 'result');
+    }
+}

--- a/src/Clients/Implementations/SubstrateSocketClient.php
+++ b/src/Clients/Implementations/SubstrateSocketClient.php
@@ -4,7 +4,7 @@ namespace Enjin\Platform\Clients\Implementations;
 
 use Enjin\Platform\Clients\Abstracts\WebsocketAbstract;
 
-class SubstrateWebsocket extends WebsocketAbstract
+class SubstrateSocketClient extends WebsocketAbstract
 {
     /**
      * Create a new websocket client instance.

--- a/src/Commands/RelayWatcher.php
+++ b/src/Commands/RelayWatcher.php
@@ -4,7 +4,7 @@ namespace Enjin\Platform\Commands;
 
 use Cache;
 use Enjin\BlockchainTools\HexConverter;
-use Enjin\Platform\Clients\Implementations\SubstrateWebsocket;
+use Enjin\Platform\Clients\Implementations\SubstrateSocketClient;
 use Enjin\Platform\Enums\Global\PlatformCache;
 use Enjin\Platform\Enums\Global\TransactionState;
 use Enjin\Platform\Enums\Substrate\StorageType;
@@ -41,13 +41,13 @@ class RelayWatcher extends Command
 
         $this->description = 'Watches managed wallet at relay chain to auto teleport their ENJ';
         $this->codec = new Codec();
-        $this->rpc = new Substrate(new SubstrateWebsocket(currentRelayUrl()));
+        $this->rpc = new Substrate(new SubstrateSocketClient(currentRelayUrl()));
         $this->decoder = new DecoderService(network: currentRelay()->value);
     }
 
     public function handle(): int
     {
-        $sub = new Substrate(new SubstrateWebsocket(currentRelayUrl()));
+        $sub = new Substrate(new SubstrateSocketClient(currentRelayUrl()));
 
         try {
             $this->warn('Subscribing to new heads');

--- a/src/Commands/Sync.php
+++ b/src/Commands/Sync.php
@@ -7,7 +7,7 @@ use Amp\Serialization\SerializationException;
 use Amp\Sync\ChannelException;
 use Carbon\Carbon;
 use Enjin\BlockchainTools\HexConverter;
-use Enjin\Platform\Clients\Implementations\SubstrateWebsocket;
+use Enjin\Platform\Clients\Implementations\SubstrateSocketClient;
 use Enjin\Platform\Commands\contexts\Truncate;
 use Enjin\Platform\Enums\Global\ModelType;
 use Enjin\Platform\Enums\Global\PlatformCache;
@@ -76,7 +76,7 @@ class Sync extends Command
      *
      * @throws Exception
      */
-    public function handle(Backoff $backoff, SubstrateWebsocket $rpc): int
+    public function handle(Backoff $backoff, SubstrateSocketClient $rpc): int
     {
         PlatformSyncing::dispatch();
 
@@ -100,7 +100,7 @@ class Sync extends Command
      *
      * @throws PlatformException
      */
-    protected function startSync(SubstrateWebsocket $rpc): void
+    protected function startSync(SubstrateSocketClient $rpc): void
     {
         Cache::forget(PlatformCache::CUSTOM_TYPES->key());
 
@@ -135,7 +135,7 @@ class Sync extends Command
     /**
      * Get the current block.
      */
-    protected function getCurrentBlock(SubstrateWebsocket $rpc): Block
+    protected function getCurrentBlock(SubstrateSocketClient $rpc): Block
     {
         $blockHash = $rpc->send('chain_getBlockHash');
         $blockNumber = Arr::get($rpc->send('chain_getBlock', [$blockHash]), 'block.header.number');

--- a/src/Commands/Transactions.php
+++ b/src/Commands/Transactions.php
@@ -6,7 +6,7 @@ use Amp\Future;
 use Amp\Parallel\Context\ProcessContextFactory;
 use Carbon\Carbon;
 use Enjin\BlockchainTools\HexConverter;
-use Enjin\Platform\Clients\Implementations\SubstrateWebsocket;
+use Enjin\Platform\Clients\Implementations\SubstrateSocketClient;
 use Enjin\Platform\Exceptions\PlatformException;
 use Enjin\Platform\Models\Laravel\Block;
 use Enjin\Platform\Services\Processor\Substrate\Codec\Codec;
@@ -42,7 +42,7 @@ class Transactions extends Command
         $this->start = now();
     }
 
-    public function handle(SubstrateWebsocket $rpc): int
+    public function handle(SubstrateSocketClient $rpc): int
     {
         $fromBlock = $this->option('from');
         if (!$fromBlock) {

--- a/src/Commands/contexts/get_extrinsics.php
+++ b/src/Commands/contexts/get_extrinsics.php
@@ -1,7 +1,7 @@
 <?php
 
 use Amp\Sync\Channel;
-use Enjin\Platform\Clients\Implementations\AsyncWebsocket;
+use Enjin\Platform\Clients\Implementations\AsyncSocketClient;
 use Illuminate\Support\Arr;
 
 return function (Channel $channel): array {
@@ -11,7 +11,7 @@ return function (Channel $channel): array {
     $current = $receivedMessage[2];
     $to = $receivedMessage[3];
 
-    $rpc = new AsyncWebsocket($nodeUrl);
+    $rpc = new AsyncSocketClient($nodeUrl);
     $data = [];
 
     while (true) {

--- a/src/Commands/contexts/get_storage.php
+++ b/src/Commands/contexts/get_storage.php
@@ -2,7 +2,7 @@
 
 use Amp\Future;
 use Amp\Sync\Channel;
-use Enjin\Platform\Clients\Implementations\AsyncWebsocket;
+use Enjin\Platform\Clients\Implementations\AsyncSocketClient;
 use Illuminate\Support\Arr;
 
 use function Amp\async;
@@ -13,8 +13,8 @@ return function (Channel $channel): array {
     $blockHash = $receivedMessage[1];
     $nodeUrl = $receivedMessage[2];
 
-    $rpcKey = new AsyncWebsocket($nodeUrl);
-    $rpcStorage = new AsyncWebsocket($nodeUrl);
+    $rpcKey = new AsyncSocketClient($nodeUrl);
+    $rpcStorage = new AsyncSocketClient($nodeUrl);
 
     $total = 0;
     $storageValues = [];

--- a/src/Providers/Deferred/WebsocketClientProvider.php
+++ b/src/Providers/Deferred/WebsocketClientProvider.php
@@ -3,7 +3,7 @@
 namespace Enjin\Platform\Providers\Deferred;
 
 use Enjin\Platform\Clients\Abstracts\WebsocketAbstract;
-use Enjin\Platform\Clients\Implementations\SubstrateWebsocket;
+use Enjin\Platform\Clients\Implementations\SubstrateSocketClient;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 
@@ -15,7 +15,7 @@ class WebsocketClientProvider extends ServiceProvider implements DeferrableProvi
     public function register()
     {
         $map = [
-            chain()->value => SubstrateWebsocket::class,
+            chain()->value => SubstrateSocketClient::class,
         ];
 
         $driverKey = chain()->value;

--- a/src/Services/Blockchain/Implementations/Substrate.php
+++ b/src/Services/Blockchain/Implementations/Substrate.php
@@ -5,6 +5,7 @@ namespace Enjin\Platform\Services\Blockchain\Implementations;
 use Crypto\sr25519;
 use Enjin\BlockchainTools\HexConverter;
 use Enjin\Platform\Clients\Abstracts\WebsocketAbstract;
+use Enjin\Platform\Clients\Implementations\SubstrateHttpClient;
 use Enjin\Platform\Enums\Global\PlatformCache;
 use Enjin\Platform\Enums\Substrate\CryptoSignatureType;
 use Enjin\Platform\Enums\Substrate\FreezeStateType;
@@ -27,6 +28,7 @@ use Enjin\Platform\Services\Processor\Substrate\Codec\Codec;
 use Enjin\Platform\Services\Processor\Substrate\Codec\Encoder;
 use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\SS58Address;
+use Exception;
 use Facades\Enjin\Platform\Services\Database\WalletService;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -384,11 +386,12 @@ class Substrate implements BlockchainServiceInterface
             $wallet = WalletService::firstOrStore(['public_key' => SS58Address::getPublicKey($wallet)]);
         }
 
-        $accountInfo = Cache::remember(
-            PlatformCache::BALANCE->key($wallet->public_key),
-            now()->addSeconds(12),
-            fn () => $this->codec->decoder()->systemAccount($this->fetchSystemAccount($wallet->public_key))
-        );
+        try {
+            $storage = $this->fetchSystemAccount($wallet->public_key);
+            $accountInfo = $this->codec->decoder()->systemAccount($storage);
+        } catch (Exception) {
+            return $wallet;
+        }
 
         $wallet->nonce = Arr::get($accountInfo, 'nonce');
         $wallet->balances = Arr::get($accountInfo, 'balances');
@@ -417,7 +420,7 @@ class Substrate implements BlockchainServiceInterface
                 sodium_hex2bin(HexConverter::unPrefix($message)),
                 sodium_hex2bin(HexConverter::unPrefix($publicKey)),
             );
-        } catch (\Exception) {
+        } catch (Exception) {
             return false;
         }
     }
@@ -430,9 +433,10 @@ class Substrate implements BlockchainServiceInterface
         return Cache::remember(
             PlatformCache::SYSTEM_ACCOUNT->key($publicKey),
             now()->addSeconds(12),
-            fn () => $this->callMethod('state_getStorage', [
-                $this->codec->encoder()->systemAccountStorageKey($publicKey),
-            ])
+            fn () => (new SubstrateHttpClient())
+                ->jsonRpc('state_getStorage', [
+                    $this->codec->encoder()->systemAccountStorageKey($publicKey),
+                ])
         );
     }
 }

--- a/src/Services/Blockchain/Implementations/Substrate.php
+++ b/src/Services/Blockchain/Implementations/Substrate.php
@@ -151,9 +151,10 @@ class Substrate implements BlockchainServiceInterface
     {
         return Cache::remember(PlatformCache::FEE->key($call), now()->addWeek(), function () use ($call) {
             $extrinsic = $this->codec->encoder()->addFakeSignature($call);
-            $result = $this->callMethod('payment_queryFeeDetails', [
-                $extrinsic,
-            ]);
+            $result = (new SubstrateHttpClient())
+                ->jsonRpc('payment_queryFeeDetails', [
+                    $extrinsic,
+                ]);
 
             $baseFee = gmp_init(Arr::get($result, 'inclusionFee.baseFee'));
             $lenFee = gmp_init(Arr::get($result, 'inclusionFee.lenFee'));

--- a/src/Services/Database/MetadataService.php
+++ b/src/Services/Database/MetadataService.php
@@ -2,7 +2,7 @@
 
 namespace Enjin\Platform\Services\Database;
 
-use Enjin\Platform\Clients\Implementations\MetadataClient;
+use Enjin\Platform\Clients\Implementations\MetadataHttpClient;
 use Enjin\Platform\Models\Laravel\Attribute;
 
 class MetadataService
@@ -10,7 +10,7 @@ class MetadataService
     /**
      * Create a new instance.
      */
-    public function __construct(protected MetadataClient $client) {}
+    public function __construct(protected MetadataHttpClient $client) {}
 
     /**
      * Fetch the metadata from the attribute URL.

--- a/src/Services/Processor/Substrate/BlockProcessor.php
+++ b/src/Services/Processor/Substrate/BlockProcessor.php
@@ -3,7 +3,7 @@
 namespace Enjin\Platform\Services\Processor\Substrate;
 
 use Enjin\BlockchainTools\HexConverter;
-use Enjin\Platform\Clients\Implementations\SubstrateWebsocket;
+use Enjin\Platform\Clients\Implementations\SubstrateSocketClient;
 use Enjin\Platform\Enums\Global\PlatformCache;
 use Enjin\Platform\Enums\Substrate\StorageKey;
 use Enjin\Platform\Events\Substrate\Commands\PlatformBlockIngested;
@@ -39,7 +39,7 @@ class BlockProcessor
         $this->input = new ArgvInput();
         $this->output = new BufferedConsoleOutput();
         $this->codec = new Codec();
-        $this->persistedClient = new Substrate(new SubstrateWebsocket());
+        $this->persistedClient = new Substrate(new SubstrateSocketClient());
     }
 
     public function latestBlock(): ?int
@@ -93,7 +93,7 @@ class BlockProcessor
 
     public function subscribeToNewHeads(): void
     {
-        $sub = new Substrate(new SubstrateWebsocket());
+        $sub = new Substrate(new SubstrateSocketClient());
         $this->warn('Starting subscription to new heads');
 
         try {

--- a/src/Services/Processor/Substrate/Codec/Encoder.php
+++ b/src/Services/Processor/Substrate/Codec/Encoder.php
@@ -6,7 +6,7 @@ use Codec\Base;
 use Codec\ScaleBytes;
 use Codec\Types\ScaleInstance;
 use Enjin\BlockchainTools\HexConverter;
-use Enjin\Platform\Clients\Implementations\SubstrateWebsocket;
+use Enjin\Platform\Clients\Implementations\SubstrateSocketClient;
 use Enjin\Platform\Enums\Global\PlatformCache;
 use Enjin\Platform\Enums\Substrate\StorageType;
 use Enjin\Platform\Exceptions\PlatformException;
@@ -407,7 +407,7 @@ class Encoder
                 return Metadata::v1012();
             }
 
-            $blockchain = new SubstrateWebsocket();
+            $blockchain = new SubstrateSocketClient();
             $response = $blockchain->send('state_getMetadata');
             $blockchain->close();
 

--- a/src/Services/Processor/Substrate/DecoderService.php
+++ b/src/Services/Processor/Substrate/DecoderService.php
@@ -2,7 +2,7 @@
 
 namespace Enjin\Platform\Services\Processor\Substrate;
 
-use Enjin\Platform\Clients\Implementations\DecoderClient;
+use Enjin\Platform\Clients\Implementations\DecoderHttpClient;
 use Enjin\Platform\Facades\Package;
 use Enjin\Platform\Services\Processor\Substrate\Codec\Polkadart\Events\Event;
 use Enjin\Platform\Services\Processor\Substrate\Codec\Polkadart\Extrinsics\Extrinsic;
@@ -15,13 +15,13 @@ use Throwable;
 
 class DecoderService
 {
-    protected DecoderClient $client;
+    protected DecoderHttpClient $client;
     protected string $host;
     protected string $network;
 
     public function __construct(?string $network = null)
     {
-        $this->client = new DecoderClient();
+        $this->client = new DecoderHttpClient();
         $this->host = config('enjin-platform.decoder_container');
         $this->network = $network ?? network()->value;
     }

--- a/src/Services/Processor/Substrate/ExtrinsicProcessor.php
+++ b/src/Services/Processor/Substrate/ExtrinsicProcessor.php
@@ -2,7 +2,7 @@
 
 namespace Enjin\Platform\Services\Processor\Substrate;
 
-use Enjin\Platform\Clients\Implementations\SubstrateWebsocket;
+use Enjin\Platform\Clients\Implementations\SubstrateSocketClient;
 use Enjin\Platform\Enums\Global\TransactionState;
 use Enjin\Platform\Enums\Substrate\StorageType;
 use Enjin\Platform\Enums\Substrate\SystemEventType;
@@ -54,7 +54,7 @@ class ExtrinsicProcessor
         if ($transaction) {
             if ($this->block->events === null) {
                 Log::info('Fetching events for block #' . $this->block->number);
-                $rpc = new SubstrateWebsocket();
+                $rpc = new SubstrateSocketClient();
                 $blockHash = $this->block->hash;
 
                 if ($blockHash === null) {

--- a/src/Services/Processor/Substrate/State.php
+++ b/src/Services/Processor/Substrate/State.php
@@ -2,7 +2,7 @@
 
 namespace Enjin\Platform\Services\Processor\Substrate;
 
-use Enjin\Platform\Clients\Implementations\SubstrateWebsocket;
+use Enjin\Platform\Clients\Implementations\SubstrateSocketClient;
 use Enjin\Platform\Enums\Global\PlatformCache;
 use Enjin\Platform\Models\CollectionAccount;
 use Enjin\Platform\Models\TokenAccount;
@@ -17,11 +17,11 @@ use Throwable;
 
 class State
 {
-    protected SubstrateWebsocket $client;
+    protected SubstrateSocketClient $client;
 
     public function __construct()
     {
-        $this->client = new SubstrateWebsocket();
+        $this->client = new SubstrateSocketClient();
     }
 
     public function __destruct()

--- a/tests/Feature/GraphQL/Mutations/AcceptCollectionTransferTest.php
+++ b/tests/Feature/GraphQL/Mutations/AcceptCollectionTransferTest.php
@@ -13,7 +13,7 @@ use Enjin\Platform\Services\Processor\Substrate\Codec\Codec;
 use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -22,7 +22,7 @@ use Illuminate\Support\Facades\Event;
 class AcceptCollectionTransferTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'AcceptCollectionTransfer';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/AcceptCollectionTransferTest.php
+++ b/tests/Feature/GraphQL/Mutations/AcceptCollectionTransferTest.php
@@ -13,7 +13,7 @@ use Enjin\Platform\Services\Processor\Substrate\Codec\Codec;
 use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -22,7 +22,7 @@ use Illuminate\Support\Facades\Event;
 class AcceptCollectionTransferTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'AcceptCollectionTransfer';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/ApproveCollectionTest.php
+++ b/tests/Feature/GraphQL/Mutations/ApproveCollectionTest.php
@@ -17,7 +17,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -26,7 +26,7 @@ use Illuminate\Support\Facades\Event;
 class ApproveCollectionTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'ApproveCollection';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/ApproveCollectionTest.php
+++ b/tests/Feature/GraphQL/Mutations/ApproveCollectionTest.php
@@ -17,7 +17,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -26,7 +26,7 @@ use Illuminate\Support\Facades\Event;
 class ApproveCollectionTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'ApproveCollection';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/ApproveTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/ApproveTokenTest.php
@@ -20,7 +20,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -29,7 +29,7 @@ use Illuminate\Support\Facades\Event;
 class ApproveTokenTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected $method = 'ApproveToken';
 

--- a/tests/Feature/GraphQL/Mutations/ApproveTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/ApproveTokenTest.php
@@ -20,7 +20,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -29,7 +29,7 @@ use Illuminate\Support\Facades\Event;
 class ApproveTokenTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected $method = 'ApproveToken';
 

--- a/tests/Feature/GraphQL/Mutations/BatchMintTest.php
+++ b/tests/Feature/GraphQL/Mutations/BatchMintTest.php
@@ -25,7 +25,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -35,7 +35,7 @@ use Illuminate\Support\Facades\Event;
 class BatchMintTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'BatchMint';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/BatchMintTest.php
+++ b/tests/Feature/GraphQL/Mutations/BatchMintTest.php
@@ -25,7 +25,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -35,7 +35,7 @@ use Illuminate\Support\Facades\Event;
 class BatchMintTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'BatchMint';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/BatchSetAttributeTest.php
+++ b/tests/Feature/GraphQL/Mutations/BatchSetAttributeTest.php
@@ -16,7 +16,7 @@ use Enjin\Platform\Services\Token\Encoders\Integer;
 use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -24,7 +24,7 @@ use Illuminate\Database\Eloquent\Model;
 class BatchSetAttributeTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'BatchSetAttribute';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/BatchSetAttributeTest.php
+++ b/tests/Feature/GraphQL/Mutations/BatchSetAttributeTest.php
@@ -16,7 +16,7 @@ use Enjin\Platform\Services\Token\Encoders\Integer;
 use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -24,7 +24,7 @@ use Illuminate\Database\Eloquent\Model;
 class BatchSetAttributeTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'BatchSetAttribute';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/BatchTransferBalanceTest.php
+++ b/tests/Feature/GraphQL/Mutations/BatchTransferBalanceTest.php
@@ -12,7 +12,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Faker\Generator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
@@ -20,7 +20,7 @@ use Illuminate\Support\Facades\Event;
 class BatchTransferBalanceTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'BatchTransferBalance';
 

--- a/tests/Feature/GraphQL/Mutations/BatchTransferBalanceTest.php
+++ b/tests/Feature/GraphQL/Mutations/BatchTransferBalanceTest.php
@@ -12,7 +12,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Faker\Generator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
@@ -20,7 +20,7 @@ use Illuminate\Support\Facades\Event;
 class BatchTransferBalanceTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'BatchTransferBalance';
 

--- a/tests/Feature/GraphQL/Mutations/BatchTransferTest.php
+++ b/tests/Feature/GraphQL/Mutations/BatchTransferTest.php
@@ -22,7 +22,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -32,7 +32,7 @@ use Illuminate\Support\Facades\Event;
 class BatchTransferTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected $method = 'BatchTransfer';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/BatchTransferTest.php
+++ b/tests/Feature/GraphQL/Mutations/BatchTransferTest.php
@@ -22,7 +22,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -32,7 +32,7 @@ use Illuminate\Support\Facades\Event;
 class BatchTransferTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected $method = 'BatchTransfer';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/BurnTest.php
+++ b/tests/Feature/GraphQL/Mutations/BurnTest.php
@@ -20,7 +20,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -29,7 +29,7 @@ use Illuminate\Support\Facades\Event;
 class BurnTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected $method = 'Burn';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/BurnTest.php
+++ b/tests/Feature/GraphQL/Mutations/BurnTest.php
@@ -20,7 +20,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -29,7 +29,7 @@ use Illuminate\Support\Facades\Event;
 class BurnTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected $method = 'Burn';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/CreateCollectionTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateCollectionTest.php
@@ -20,7 +20,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Support\Facades\Event;
@@ -28,7 +28,7 @@ use Illuminate\Support\Facades\Event;
 class CreateCollectionTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'CreateCollection';
 

--- a/tests/Feature/GraphQL/Mutations/CreateCollectionTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateCollectionTest.php
@@ -20,7 +20,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Support\Facades\Event;
@@ -28,7 +28,7 @@ use Illuminate\Support\Facades\Event;
 class CreateCollectionTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'CreateCollection';
 

--- a/tests/Feature/GraphQL/Mutations/CreateTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateTokenTest.php
@@ -22,7 +22,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -31,7 +31,7 @@ use Illuminate\Support\Facades\Event;
 class CreateTokenTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'CreateToken';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/CreateTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateTokenTest.php
@@ -22,7 +22,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -31,7 +31,7 @@ use Illuminate\Support\Facades\Event;
 class CreateTokenTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'CreateToken';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/DestroyCollectionTest.php
+++ b/tests/Feature/GraphQL/Mutations/DestroyCollectionTest.php
@@ -16,7 +16,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -25,7 +25,7 @@ use Illuminate\Support\Facades\Event;
 class DestroyCollectionTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'DestroyCollection';
 

--- a/tests/Feature/GraphQL/Mutations/DestroyCollectionTest.php
+++ b/tests/Feature/GraphQL/Mutations/DestroyCollectionTest.php
@@ -16,7 +16,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -25,7 +25,7 @@ use Illuminate\Support\Facades\Event;
 class DestroyCollectionTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'DestroyCollection';
 

--- a/tests/Feature/GraphQL/Mutations/FreezeTest.php
+++ b/tests/Feature/GraphQL/Mutations/FreezeTest.php
@@ -23,7 +23,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -32,7 +32,7 @@ use Illuminate\Support\Facades\Event;
 class FreezeTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'Freeze';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/FreezeTest.php
+++ b/tests/Feature/GraphQL/Mutations/FreezeTest.php
@@ -23,7 +23,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -32,7 +32,7 @@ use Illuminate\Support\Facades\Event;
 class FreezeTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'Freeze';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/MintTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/MintTokenTest.php
@@ -19,7 +19,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -28,7 +28,7 @@ use Illuminate\Support\Facades\Event;
 class MintTokenTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'MintToken';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/MintTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/MintTokenTest.php
@@ -19,7 +19,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -28,7 +28,7 @@ use Illuminate\Support\Facades\Event;
 class MintTokenTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'MintToken';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/MutateCollectionTest.php
+++ b/tests/Feature/GraphQL/Mutations/MutateCollectionTest.php
@@ -18,7 +18,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -27,7 +27,7 @@ use Illuminate\Support\Facades\Event;
 class MutateCollectionTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'MutateCollection';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/MutateCollectionTest.php
+++ b/tests/Feature/GraphQL/Mutations/MutateCollectionTest.php
@@ -18,7 +18,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -27,7 +27,7 @@ use Illuminate\Support\Facades\Event;
 class MutateCollectionTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'MutateCollection';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/MutateTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/MutateTokenTest.php
@@ -19,7 +19,7 @@ use Enjin\Platform\Services\Token\Encoders\Integer;
 use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -28,7 +28,7 @@ use Illuminate\Support\Facades\Event;
 class MutateTokenTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'MutateToken';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/MutateTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/MutateTokenTest.php
@@ -19,7 +19,7 @@ use Enjin\Platform\Services\Token\Encoders\Integer;
 use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -28,7 +28,7 @@ use Illuminate\Support\Facades\Event;
 class MutateTokenTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'MutateToken';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/OperatorTransferTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/OperatorTransferTokenTest.php
@@ -21,7 +21,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -30,7 +30,8 @@ use Illuminate\Support\Facades\Event;
 class OperatorTransferTokenTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
+
 
     protected string $method = 'OperatorTransferToken';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/OperatorTransferTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/OperatorTransferTokenTest.php
@@ -21,7 +21,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -30,7 +30,7 @@ use Illuminate\Support\Facades\Event;
 class OperatorTransferTokenTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'OperatorTransferToken';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/RemoveAllAttributesTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveAllAttributesTest.php
@@ -19,7 +19,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -28,7 +28,7 @@ use Illuminate\Support\Facades\Event;
 class RemoveAllAttributesTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'RemoveAllAttributes';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/RemoveAllAttributesTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveAllAttributesTest.php
@@ -19,7 +19,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -28,7 +28,7 @@ use Illuminate\Support\Facades\Event;
 class RemoveAllAttributesTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'RemoveAllAttributes';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/RemoveCollectionAttributeTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveCollectionAttributeTest.php
@@ -17,7 +17,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -26,7 +26,7 @@ use Illuminate\Support\Facades\Event;
 class RemoveCollectionAttributeTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'RemoveCollectionAttribute';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/RemoveCollectionAttributeTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveCollectionAttributeTest.php
@@ -17,7 +17,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -26,7 +26,7 @@ use Illuminate\Support\Facades\Event;
 class RemoveCollectionAttributeTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'RemoveCollectionAttribute';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/RemoveTokenAttributeTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveTokenAttributeTest.php
@@ -19,7 +19,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -28,7 +28,7 @@ use Illuminate\Support\Facades\Event;
 class RemoveTokenAttributeTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'RemoveTokenAttribute';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/RemoveTokenAttributeTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveTokenAttributeTest.php
@@ -19,7 +19,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -28,7 +28,7 @@ use Illuminate\Support\Facades\Event;
 class RemoveTokenAttributeTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'RemoveTokenAttribute';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/SendTransactionTest.php
+++ b/tests/Feature/GraphQL/Mutations/SendTransactionTest.php
@@ -9,7 +9,7 @@ use Enjin\Platform\Events\Global\TransactionUpdated;
 use Enjin\Platform\Models\Transaction;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Support\Facades\Event;
@@ -17,7 +17,7 @@ use Illuminate\Support\Facades\Event;
 class SendTransactionTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'SendTransaction';
 

--- a/tests/Feature/GraphQL/Mutations/SetCollectionAttributeTest.php
+++ b/tests/Feature/GraphQL/Mutations/SetCollectionAttributeTest.php
@@ -15,7 +15,7 @@ use Enjin\Platform\Services\Processor\Substrate\Codec\Codec;
 use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -24,7 +24,7 @@ use Illuminate\Support\Facades\Event;
 class SetCollectionAttributeTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'SetCollectionAttribute';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/SetCollectionAttributeTest.php
+++ b/tests/Feature/GraphQL/Mutations/SetCollectionAttributeTest.php
@@ -15,7 +15,7 @@ use Enjin\Platform\Services\Processor\Substrate\Codec\Codec;
 use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -24,7 +24,7 @@ use Illuminate\Support\Facades\Event;
 class SetCollectionAttributeTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'SetCollectionAttribute';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/SetTokenAttributeTest.php
+++ b/tests/Feature/GraphQL/Mutations/SetTokenAttributeTest.php
@@ -18,7 +18,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -27,7 +27,7 @@ use Illuminate\Support\Facades\Event;
 class SetTokenAttributeTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'SetTokenAttribute';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/SetTokenAttributeTest.php
+++ b/tests/Feature/GraphQL/Mutations/SetTokenAttributeTest.php
@@ -18,7 +18,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -27,7 +27,7 @@ use Illuminate\Support\Facades\Event;
 class SetTokenAttributeTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'SetTokenAttribute';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/SimpleTransferTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/SimpleTransferTokenTest.php
@@ -21,7 +21,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -30,7 +30,7 @@ use Illuminate\Support\Facades\Event;
 class SimpleTransferTokenTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'SimpleTransferToken';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/SimpleTransferTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/SimpleTransferTokenTest.php
@@ -21,7 +21,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -30,7 +30,7 @@ use Illuminate\Support\Facades\Event;
 class SimpleTransferTokenTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'SimpleTransferToken';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/ThawTest.php
+++ b/tests/Feature/GraphQL/Mutations/ThawTest.php
@@ -22,7 +22,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -31,7 +31,7 @@ use Illuminate\Support\Facades\Event;
 class ThawTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'Thaw';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/ThawTest.php
+++ b/tests/Feature/GraphQL/Mutations/ThawTest.php
@@ -22,7 +22,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -31,7 +31,7 @@ use Illuminate\Support\Facades\Event;
 class ThawTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'Thaw';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/TransferAllBalanceTest.php
+++ b/tests/Feature/GraphQL/Mutations/TransferAllBalanceTest.php
@@ -12,7 +12,7 @@ use Enjin\Platform\Services\Processor\Substrate\Codec\Codec;
 use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Support\Facades\Event;
@@ -20,7 +20,7 @@ use Illuminate\Support\Facades\Event;
 class TransferAllBalanceTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'TransferAllBalance';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/TransferAllBalanceTest.php
+++ b/tests/Feature/GraphQL/Mutations/TransferAllBalanceTest.php
@@ -12,7 +12,7 @@ use Enjin\Platform\Services\Processor\Substrate\Codec\Codec;
 use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Support\Facades\Event;
@@ -20,7 +20,7 @@ use Illuminate\Support\Facades\Event;
 class TransferAllBalanceTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'TransferAllBalance';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/TransferAllowDeathTest.php
+++ b/tests/Feature/GraphQL/Mutations/TransferAllowDeathTest.php
@@ -13,14 +13,14 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Faker\Generator;
 use Illuminate\Support\Facades\Event;
 
 class TransferAllowDeathTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'TransferAllowDeath';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/TransferAllowDeathTest.php
+++ b/tests/Feature/GraphQL/Mutations/TransferAllowDeathTest.php
@@ -13,14 +13,14 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Faker\Generator;
 use Illuminate\Support\Facades\Event;
 
 class TransferAllowDeathTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'TransferAllowDeath';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/TransferAllowDeathTest.php
+++ b/tests/Feature/GraphQL/Mutations/TransferAllowDeathTest.php
@@ -25,6 +25,7 @@ class TransferAllowDeathTest extends TestCaseGraphQL
     protected string $method = 'TransferAllowDeath';
     protected Codec $codec;
     protected string $defaultAccount;
+    protected array $fee;
 
     protected function setUp(): void
     {
@@ -32,10 +33,13 @@ class TransferAllowDeathTest extends TestCaseGraphQL
 
         $this->codec = new Codec();
         $this->defaultAccount = Account::daemonPublicKey();
+
+        if (static::class === self::class) {
+            $this->mockFee($this->fee = app(Generator::class)->fee_details());
+        }
     }
 
     // Happy Path
-
     public function test_it_can_skip_validation(): void
     {
         Wallet::factory([
@@ -48,7 +52,6 @@ class TransferAllowDeathTest extends TestCaseGraphQL
             value: $amount = fake()->numberBetween(),
         ));
 
-        $this->mockFee($feeDetails = app(Generator::class)->fee_details());
         $response = $this->graphql($this->method, [
             'recipient' => SS58Address::encode($this->defaultAccount),
             'amount' => $amount,
@@ -62,8 +65,8 @@ class TransferAllowDeathTest extends TestCaseGraphQL
             'method' => $this->method,
             'state' => TransactionState::PENDING->name,
             'encodedData' => $encodedData,
-            'fee' => $feeDetails['fakeSum'],
             'deposit' => null,
+            'fee' => $this->fee['fakeSum'],
             'wallet' => [
                 'account' => [
                     'publicKey' => $publicKey,

--- a/tests/Feature/GraphQL/Mutations/TransferKeepAliveTest.php
+++ b/tests/Feature/GraphQL/Mutations/TransferKeepAliveTest.php
@@ -5,13 +5,13 @@ namespace Enjin\Platform\Tests\Feature\GraphQL\Mutations;
 use Enjin\Platform\Events\Global\TransactionCreated;
 use Enjin\Platform\Models\Wallet;
 use Enjin\Platform\Tests\Support\Mocks\StorageMock;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Faker\Generator;
 use Illuminate\Support\Facades\Event;
 
 class TransferKeepAliveTest extends TransferAllowDeathTest
 {
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'TransferKeepAlive';
 

--- a/tests/Feature/GraphQL/Mutations/UnapproveCollectionTest.php
+++ b/tests/Feature/GraphQL/Mutations/UnapproveCollectionTest.php
@@ -17,7 +17,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -26,7 +26,7 @@ use Illuminate\Support\Facades\Event;
 class UnapproveCollectionTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'UnapproveCollection';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/UnapproveCollectionTest.php
+++ b/tests/Feature/GraphQL/Mutations/UnapproveCollectionTest.php
@@ -17,7 +17,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -26,7 +26,7 @@ use Illuminate\Support\Facades\Event;
 class UnapproveCollectionTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'UnapproveCollection';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/UnapproveTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/UnapproveTokenTest.php
@@ -21,7 +21,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -30,7 +30,7 @@ use Illuminate\Support\Facades\Event;
 class UnapproveTokenTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
 
     protected string $method = 'UnapproveToken';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Mutations/UnapproveTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/UnapproveTokenTest.php
@@ -21,7 +21,7 @@ use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
@@ -30,7 +30,7 @@ use Illuminate\Support\Facades\Event;
 class UnapproveTokenTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'UnapproveToken';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Queries/GetWalletAuthTest.php
+++ b/tests/Feature/GraphQL/Queries/GetWalletAuthTest.php
@@ -9,7 +9,7 @@ use Enjin\Platform\Models\Wallet;
 use Enjin\Platform\Services\Processor\Substrate\Codec\Codec;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
@@ -18,7 +18,7 @@ use Rebing\GraphQL\GraphQLServiceProvider;
 class GetWalletAuthTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'GetWallet';
     protected Codec $codec;

--- a/tests/Feature/GraphQL/Queries/GetWalletTest.php
+++ b/tests/Feature/GraphQL/Queries/GetWalletTest.php
@@ -147,7 +147,7 @@ class GetWalletTest extends TestCaseGraphQL
 
     public function test_it_can_get_wallet_with_all_data_by_id(): void
     {
-        $this->mockNonceAndBalancesFor($this->wallet->public_key);
+        $this->mockNonceAndBalance();
 
         $response = $this->graphql($this->method, [
             'id' => $this->wallet->id,
@@ -376,7 +376,7 @@ class GetWalletTest extends TestCaseGraphQL
 
     public function test_it_can_get_a_wallet_and_filter_collection_accounts(): void
     {
-        $this->mockNonceAndBalancesFor($this->wallet->public_key);
+        $this->mockNonceAndBalance();
 
         $response = $this->graphql($this->method, [
             'id' => $id = $this->wallet->id,
@@ -393,7 +393,7 @@ class GetWalletTest extends TestCaseGraphQL
 
     public function test_it_can_get_a_wallet_and_filter_token_accounts(): void
     {
-        $this->mockNonceAndBalancesFor($this->wallet->public_key);
+        $this->mockNonceAndBalance();
 
         $response = $this->graphql($this->method, [
             'id' => $id = $this->wallet->id,
@@ -434,7 +434,7 @@ class GetWalletTest extends TestCaseGraphQL
 
     public function test_it_can_get_a_wallet_and_filter_owned_collections(): void
     {
-        $this->mockNonceAndBalancesFor($this->wallet->public_key);
+        $this->mockNonceAndBalance();
 
         $response = $this->graphql($this->method, [
             'id' => $id = $this->wallet->id,
@@ -483,7 +483,7 @@ class GetWalletTest extends TestCaseGraphQL
 
     public function test_it_can_get_wallet_by_external_id(): void
     {
-        $this->mockNonceAndBalancesFor($this->wallet->public_key);
+        $this->mockNonceAndBalance();
 
         $response = $this->graphql($this->method, [
             'externalId' => $externalId = $this->wallet->external_id,
@@ -497,7 +497,7 @@ class GetWalletTest extends TestCaseGraphQL
 
     public function test_it_can_get_wallet_by_address(): void
     {
-        $this->mockNonceAndBalancesFor($this->wallet->public_key);
+        $this->mockNonceAndBalance();
 
         $response = $this->graphql($this->method, [
             'account' => SS58Address::encode($this->wallet->public_key),
@@ -515,7 +515,7 @@ class GetWalletTest extends TestCaseGraphQL
 
     public function test_it_can_get_wallet_by_verification_id(): void
     {
-        $this->mockNonceAndBalancesFor($this->wallet->public_key);
+        $this->mockNonceAndBalance();
 
         $response = $this->graphql($this->method, [
             'verificationId' => $this->wallet->verification_id,
@@ -749,13 +749,9 @@ class GetWalletTest extends TestCaseGraphQL
         );
     }
 
-    protected function mockNonceAndBalancesFor(string $address): void
+    protected function mockNonceAndBalance(): void
     {
         $this->mockHttpClient(
-            'state_getStorage',
-            [
-                $this->codec->encoder()->systemAccountStorageKey($address),
-            ],
             json_encode(
                 [
                     'jsonrpc' => '2.0',

--- a/tests/Feature/GraphQL/Queries/GetWalletTest.php
+++ b/tests/Feature/GraphQL/Queries/GetWalletTest.php
@@ -18,7 +18,8 @@ use Enjin\Platform\Services\Processor\Substrate\Codec\Codec;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
@@ -26,7 +27,8 @@ use Illuminate\Support\Arr;
 class GetWalletTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksHttpClient;
+    use MocksSocketClient;
 
     protected string $method = 'GetWallet';
 
@@ -749,7 +751,7 @@ class GetWalletTest extends TestCaseGraphQL
 
     protected function mockNonceAndBalancesFor(string $address): void
     {
-        $this->mockWebsocketClient(
+        $this->mockHttpClient(
             'state_getStorage',
             [
                 $this->codec->encoder()->systemAccountStorageKey($address),

--- a/tests/Feature/GraphQL/Queries/GetWalletsTest.php
+++ b/tests/Feature/GraphQL/Queries/GetWalletsTest.php
@@ -17,7 +17,7 @@ use Enjin\Platform\Models\Wallet;
 use Enjin\Platform\Services\Processor\Substrate\Codec\Codec;
 use Enjin\Platform\Support\Hex;
 use Enjin\Platform\Tests\Feature\GraphQL\TestCaseGraphQL;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection as SupportCollection;
@@ -26,7 +26,7 @@ use Illuminate\Support\Str;
 class GetWalletsTest extends TestCaseGraphQL
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
 
     protected string $method = 'GetWallets';
 

--- a/tests/Support/Mocks/StorageMock.php
+++ b/tests/Support/Mocks/StorageMock.php
@@ -14,6 +14,13 @@ class StorageMock
         return self::jsonRpcIt('0x000000000000000001000000000000000000c84e676dc11b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000');
     }
 
+    public static function fee(array $mockedFee)
+    {
+        return self::jsonRpcIt([
+            'inclusionFee' => $mockedFee,
+        ]);
+    }
+
     protected static function jsonRpcIt(array|string|null $result)
     {
         return json_encode([

--- a/tests/Support/MocksHttpClient.php
+++ b/tests/Support/MocksHttpClient.php
@@ -2,46 +2,36 @@
 
 namespace Enjin\Platform\Tests\Support;
 
-use Enjin\Platform\Support\JSON;
-use Enjin\Platform\Support\Util;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 
 trait MocksHttpClient
 {
-    private function mockHttpClient(string $method, array $params, string $responseJson, bool $anyParam = false): void
+    protected function mockFee(array $mockedFee): void
     {
-        $expectedRpcRequest = Util::createJsonRpc($method, $params);
+        $this->mockHttpClient(
+            json_encode(
+                [
+                    'jsonrpc' => '2.0',
+                    'result' => [
+                        'inclusionFee' => $mockedFee,
+                    ],
+                    'id' => 1,
+                ],
+                JSON_THROW_ON_ERROR
+            )
+        );
+    }
 
+    protected function mockHttpClient(string $responseJson): void
+    {
         Http::fake([
             '*' => Http::response($responseJson),
         ]);
-
-        Http::assertSent(function (Request $request) use ($expectedRpcRequest) {
-
-            ray($request);
-            ray($expectedRpcRequest);
-
-            return $this->assertRequestEquals($expectedRpcRequest, json_encode($request->data()));
-        });
     }
 
-    private function mockHttpClientSequence(array $responseSequence): void
+    protected function mockHttpClientSequence(array $responseSequence): void
     {
         Http::fake(fn (Request $request) => Http::response(array_shift($responseSequence)));
-    }
-
-    /**
-     * @throws \JsonException
-     */
-    protected function assertRequestEquals(string $expected, string $actual): bool
-    {
-        $expected = JSON::decode($expected, true, 512, JSON_THROW_ON_ERROR);
-        unset($expected['id']);
-
-        $actual = JSON::decode($actual, true, 512, JSON_THROW_ON_ERROR);
-        unset($actual['id']);
-
-        return $expected === $actual;
     }
 }

--- a/tests/Support/MocksHttpClient.php
+++ b/tests/Support/MocksHttpClient.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Enjin\Platform\Tests\Support;
+
+use Enjin\Platform\Support\JSON;
+use Enjin\Platform\Support\Util;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+trait MocksHttpClient
+{
+    private function mockHttpClient(string $method, array $params, string $responseJson, bool $anyParam = false): void
+    {
+        $expectedRpcRequest = Util::createJsonRpc($method, $params);
+
+        Http::fake([
+            '*' => Http::response($responseJson),
+        ]);
+
+        Http::assertSent(function (Request $request) use ($expectedRpcRequest) {
+
+            ray($request);
+            ray($expectedRpcRequest);
+
+            return $this->assertRequestEquals($expectedRpcRequest, json_encode($request->data()));
+        });
+    }
+
+    private function mockHttpClientSequence(array $responseSequence): void
+    {
+        Http::fake(fn (Request $request) => Http::response(array_shift($responseSequence)));
+    }
+
+    /**
+     * @throws \JsonException
+     */
+    protected function assertRequestEquals(string $expected, string $actual): bool
+    {
+        $expected = JSON::decode($expected, true, 512, JSON_THROW_ON_ERROR);
+        unset($expected['id']);
+
+        $actual = JSON::decode($actual, true, 512, JSON_THROW_ON_ERROR);
+        unset($actual['id']);
+
+        return $expected === $actual;
+    }
+}

--- a/tests/Support/MocksSocketClient.php
+++ b/tests/Support/MocksSocketClient.php
@@ -9,10 +9,7 @@ use WebSocket\Client;
 
 trait MocksSocketClient
 {
-    /**
-     * @throws \JsonException
-     */
-    protected function assertRpcResponseEquals(string $expected, string $actual)
+    protected function assertRpcResponseEquals(string $expected, string $actual): void
     {
         $expected = JSON::decode($expected, true, 512, JSON_THROW_ON_ERROR);
         unset($expected['id']);
@@ -40,7 +37,7 @@ trait MocksSocketClient
                 $mock->shouldReceive('send')
                     ->once()
                     ->with(Mockery::on(function ($rpcRequest) use ($expectedRpcRequest) {
-                        $this->assertRequestEquals($expectedRpcRequest, $rpcRequest);
+                        $this->assertRpcResponseEquals($expectedRpcRequest, $rpcRequest);
 
                         return true;
                     }));
@@ -54,9 +51,6 @@ trait MocksSocketClient
         });
     }
 
-    /**
-     * @throws \JsonException
-     */
     protected function mockWebsocketClientSequence(array $responseSequence): void
     {
         app()->bind(Client::class, function () use ($responseSequence) {

--- a/tests/Support/MocksSocketClient.php
+++ b/tests/Support/MocksSocketClient.php
@@ -9,25 +9,6 @@ use WebSocket\Client;
 
 trait MocksSocketClient
 {
-    protected function mockFee(array $mockedFee): void
-    {
-        $this->mockWebsocketClient(
-            'payment_queryFeeDetails',
-            [],
-            json_encode(
-                [
-                    'jsonrpc' => '2.0',
-                    'result' => [
-                        'inclusionFee' => $mockedFee,
-                    ],
-                    'id' => 1,
-                ],
-                JSON_THROW_ON_ERROR
-            ),
-            true,
-        );
-    }
-
     /**
      * @throws \JsonException
      */
@@ -45,7 +26,7 @@ trait MocksSocketClient
     /**
      * @throws \JsonException
      */
-    private function mockWebsocketClient(string $method, array $params, string $responseJson, bool $anyParam = false): void
+    protected function mockWebsocketClient(string $method, array $params, string $responseJson, bool $anyParam = false): void
     {
         $expectedRpcRequest = Util::createJsonRpc($method, $params);
 
@@ -76,7 +57,7 @@ trait MocksSocketClient
     /**
      * @throws \JsonException
      */
-    private function mockWebsocketClientSequence(array $responseSequence): void
+    protected function mockWebsocketClientSequence(array $responseSequence): void
     {
         app()->bind(Client::class, function () use ($responseSequence) {
             $mock = Mockery::mock(Client::class);

--- a/tests/Support/MocksSocketClient.php
+++ b/tests/Support/MocksSocketClient.php
@@ -7,7 +7,7 @@ use Enjin\Platform\Support\Util;
 use Mockery;
 use WebSocket\Client;
 
-trait MocksWebsocketClient
+trait MocksSocketClient
 {
     protected function mockFee(array $mockedFee): void
     {
@@ -59,7 +59,7 @@ trait MocksWebsocketClient
                 $mock->shouldReceive('send')
                     ->once()
                     ->with(Mockery::on(function ($rpcRequest) use ($expectedRpcRequest) {
-                        $this->assertRpcResponseEquals($expectedRpcRequest, $rpcRequest);
+                        $this->assertRequestEquals($expectedRpcRequest, $rpcRequest);
 
                         return true;
                     }));

--- a/tests/Unit/DepositFeeTest.php
+++ b/tests/Unit/DepositFeeTest.php
@@ -9,7 +9,7 @@ use Enjin\Platform\Enums\Global\PlatformCache;
 use Enjin\Platform\GraphQL\Schemas\Primary\Traits\HasTransactionDeposit;
 use Enjin\Platform\Models\Collection;
 use Enjin\Platform\Models\Token;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Enjin\Platform\Tests\TestCase;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
@@ -17,7 +17,7 @@ use Faker\Generator;
 class DepositFeeTest extends TestCase
 {
     use HasTransactionDeposit;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
     protected static bool $initialized = false;
 
     protected function setUp(): void

--- a/tests/Unit/DepositFeeTest.php
+++ b/tests/Unit/DepositFeeTest.php
@@ -9,7 +9,7 @@ use Enjin\Platform\Enums\Global\PlatformCache;
 use Enjin\Platform\GraphQL\Schemas\Primary\Traits\HasTransactionDeposit;
 use Enjin\Platform\Models\Collection;
 use Enjin\Platform\Models\Token;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Enjin\Platform\Tests\TestCase;
 use Facades\Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Faker\Generator;
@@ -17,7 +17,7 @@ use Faker\Generator;
 class DepositFeeTest extends TestCase
 {
     use HasTransactionDeposit;
-    use MocksSocketClient;
+    use MocksHttpClient;
     protected static bool $initialized = false;
 
     protected function setUp(): void

--- a/tests/Unit/WalletTest.php
+++ b/tests/Unit/WalletTest.php
@@ -3,7 +3,7 @@
 namespace Enjin\Platform\Tests\Unit;
 
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
-use Enjin\Platform\Clients\Implementations\SubstrateWebsocket;
+use Enjin\Platform\Clients\Implementations\SubstrateSocketClient;
 use Enjin\Platform\Models\Wallet;
 use Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Enjin\Platform\Support\SS58Address;
@@ -25,7 +25,7 @@ final class WalletTest extends TestCase
     {
         parent::setUp();
 
-        $ws = new SubstrateWebsocket('ws://localhost');
+        $ws = new SubstrateSocketClient('ws://localhost');
         $this->blockchainService = new Substrate($ws);
     }
 

--- a/tests/Unit/WalletTest.php
+++ b/tests/Unit/WalletTest.php
@@ -8,7 +8,7 @@ use Enjin\Platform\Models\Wallet;
 use Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Support\Mocks\StorageMock;
-use Enjin\Platform\Tests\Support\MocksSocketClient;
+use Enjin\Platform\Tests\Support\MocksHttpClient;
 use Enjin\Platform\Tests\TestCase;
 use Faker\Generator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -16,7 +16,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 final class WalletTest extends TestCase
 {
     use ArraySubsetAsserts;
-    use MocksSocketClient;
+    use MocksHttpClient;
     use RefreshDatabase;
 
     protected Substrate $blockchainService;
@@ -38,7 +38,7 @@ final class WalletTest extends TestCase
 
     public function test_it_returns_a_zero_balance_if_no_saved_wallet_and_no_storage_for_the_address()
     {
-        $this->mockWebsocketClientSequence([
+        $this->mockHttpClientSequence([
             StorageMock::null_account_storage(),
         ]);
 
@@ -62,7 +62,7 @@ final class WalletTest extends TestCase
 
     public function test_it_returns_zero_balance_when_there_is_a_saved_wallet_and_no_storage()
     {
-        $this->mockWebsocketClientSequence([
+        $this->mockHttpClientSequence([
             StorageMock::null_account_storage(),
         ]);
 
@@ -95,7 +95,7 @@ final class WalletTest extends TestCase
 
     public function test_it_returns_a_balance_when_no_saved_wallet_and_has_storage()
     {
-        $this->mockWebsocketClientSequence([
+        $this->mockHttpClientSequence([
             StorageMock::account_with_balance(),
         ]);
 
@@ -119,7 +119,7 @@ final class WalletTest extends TestCase
 
     public function test_it_returns_a_balance_when_there_is_saved_wallet_and_has_storage()
     {
-        $this->mockWebsocketClientSequence([
+        $this->mockHttpClientSequence([
             StorageMock::account_with_balance(),
         ]);
 

--- a/tests/Unit/WalletTest.php
+++ b/tests/Unit/WalletTest.php
@@ -8,7 +8,7 @@ use Enjin\Platform\Models\Wallet;
 use Enjin\Platform\Services\Blockchain\Implementations\Substrate;
 use Enjin\Platform\Support\SS58Address;
 use Enjin\Platform\Tests\Support\Mocks\StorageMock;
-use Enjin\Platform\Tests\Support\MocksWebsocketClient;
+use Enjin\Platform\Tests\Support\MocksSocketClient;
 use Enjin\Platform\Tests\TestCase;
 use Faker\Generator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -16,7 +16,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 final class WalletTest extends TestCase
 {
     use ArraySubsetAsserts;
-    use MocksWebsocketClient;
+    use MocksSocketClient;
     use RefreshDatabase;
 
     protected Substrate $blockchainService;


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix


___

### **Description**
- Introduced a new `SubstrateHttpClient` class for handling HTTP requests with JSON-RPC.
- Renamed several client classes to better reflect their functionality, such as `SubstrateWebsocket` to `SubstrateSocketClient`.
- Updated various services and commands to use the newly renamed `SubstrateSocketClient`.
- Improved error handling in the `Substrate` service implementation.
- Updated unit tests to reflect the changes in client class names.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>18 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>AsyncSocketClient.php</strong><dd><code>Rename AsyncWebsocket to AsyncSocketClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Clients/Implementations/AsyncSocketClient.php

- Renamed class from `AsyncWebsocket` to `AsyncSocketClient`.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-b949a05cfd61e12fbd81fcfc36be1e53205012f31764969ee67228cc3e895779">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DecoderHttpClient.php</strong><dd><code>Rename DecoderClient to DecoderHttpClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Clients/Implementations/DecoderHttpClient.php

- Renamed class from `DecoderClient` to `DecoderHttpClient`.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-dc57c2d36bcdd58d00bec6588862da5d6dbed3d1e9d02f8c8e3a10e6cf91d0ae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>MetadataHttpClient.php</strong><dd><code>Rename MetadataClient to MetadataHttpClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Clients/Implementations/MetadataHttpClient.php

- Renamed class from `MetadataClient` to `MetadataHttpClient`.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-45974cb56677e6469c684f73d070c0f15465c2ea140487f1a856c532b065a41d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SubstrateHttpClient.php</strong><dd><code>Add SubstrateHttpClient for JSON-RPC requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Clients/Implementations/SubstrateHttpClient.php

<li>Added new class <code>SubstrateHttpClient</code> for HTTP client functionality.<br> <li> Implemented <code>jsonRpc</code> method for JSON-RPC requests.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-1ee94bb90a4c71f8ba464372328c4aceef619a6975a6c31bfbfea75d39c29a2c">+39/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SubstrateSocketClient.php</strong><dd><code>Rename SubstrateWebsocket to SubstrateSocketClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Clients/Implementations/SubstrateSocketClient.php

<li>Renamed class from <code>SubstrateWebsocket</code> to <code>SubstrateSocketClient</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-c53ca5b352bd2cff81f57e7b2b791dbbeb8a88125540d69621bede5ccec48c36">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RelayWatcher.php</strong><dd><code>Update RelayWatcher to use SubstrateSocketClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Commands/RelayWatcher.php

<li>Updated usage from <code>SubstrateWebsocket</code> to <code>SubstrateSocketClient</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-48110bb63d25893338956f8dcdb6ba722c4671edff58ddeedcbae42d6552e617">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Sync.php</strong><dd><code>Update Sync command to use SubstrateSocketClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Commands/Sync.php

<li>Updated usage from <code>SubstrateWebsocket</code> to <code>SubstrateSocketClient</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-9b0a60cf1d209941117e6dc62d39f195a8fb08d7e6510e532321c5ee01c6f66b">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Transactions.php</strong><dd><code>Update Transactions command to use SubstrateSocketClient</code>&nbsp; </dd></summary>
<hr>

src/Commands/Transactions.php

<li>Updated usage from <code>SubstrateWebsocket</code> to <code>SubstrateSocketClient</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-27cdf818ecde3ee0013591b674798b202f55c4cc3df36bd151a3b415fbcdb012">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>get_extrinsics.php</strong><dd><code>Update context to use AsyncSocketClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Commands/contexts/get_extrinsics.php

- Updated usage from `AsyncWebsocket` to `AsyncSocketClient`.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-6d3a908fe58d995937290d169118f8d2255df0aaa70ccbf34c7b5773f0a4febe">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>get_storage.php</strong><dd><code>Update context to use AsyncSocketClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Commands/contexts/get_storage.php

- Updated usage from `AsyncWebsocket` to `AsyncSocketClient`.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-c77c549a5f6635a3893e5a46b5ba48ea52f6dddd851a6b7396a720523b57fdfa">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>WebsocketClientProvider.php</strong><dd><code>Update WebsocketClientProvider to use SubstrateSocketClient</code></dd></summary>
<hr>

src/Providers/Deferred/WebsocketClientProvider.php

<li>Updated usage from <code>SubstrateWebsocket</code> to <code>SubstrateSocketClient</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-b9820c1895c862bcd23ac4085afbcc650392715a2f5a223070290e378e2d39b4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Substrate.php</strong><dd><code>Use SubstrateHttpClient for system account fetching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Blockchain/Implementations/Substrate.php

<li>Added <code>SubstrateHttpClient</code> usage for fetching system account.<br> <li> Improved error handling with try-catch blocks.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-c31502aa2f1476099673a2f9744b629d87d0c00ecf3c56e3269804cadc59b3ed">+13/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>MetadataService.php</strong><dd><code>Update MetadataService to use MetadataHttpClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Database/MetadataService.php

- Updated usage from `MetadataClient` to `MetadataHttpClient`.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-81af9cad135cb3d44832130138aba169cfa1ee5407d78da7aae4f0d573e9ac3d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BlockProcessor.php</strong><dd><code>Update BlockProcessor to use SubstrateSocketClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/BlockProcessor.php

<li>Updated usage from <code>SubstrateWebsocket</code> to <code>SubstrateSocketClient</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-5e9d1640ff87e611a83e41e14038785fc69b77343a16a046571f964b5f3db954">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Encoder.php</strong><dd><code>Update Encoder to use SubstrateSocketClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Codec/Encoder.php

<li>Updated usage from <code>SubstrateWebsocket</code> to <code>SubstrateSocketClient</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-9cf4c9f5fbba52860e055d9fd9d792ee1341497b92819d63b7bb327e9459def4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DecoderService.php</strong><dd><code>Update DecoderService to use DecoderHttpClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/DecoderService.php

- Updated usage from `DecoderClient` to `DecoderHttpClient`.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-ee2e97bb5c16175368f7ae78ff061939e97dde23557e6ab132203ef05526815a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ExtrinsicProcessor.php</strong><dd><code>Update ExtrinsicProcessor to use SubstrateSocketClient</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/ExtrinsicProcessor.php

<li>Updated usage from <code>SubstrateWebsocket</code> to <code>SubstrateSocketClient</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-4fcc9c507292feff5eef58370b514f726b3400ee7d1d19916508f415aef605ea">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>State.php</strong><dd><code>Update State to use SubstrateSocketClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/State.php

<li>Updated usage from <code>SubstrateWebsocket</code> to <code>SubstrateSocketClient</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-fbf349591fad571cde37b95893ad8b630a6124483377ee2cbd1a7b1350e12064">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>WalletTest.php</strong><dd><code>Update WalletTest to use SubstrateSocketClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/WalletTest.php

- Updated test setup to use `SubstrateSocketClient`.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/254/files#diff-3275f2a1f3200609b80cc092abc3dabab65c98aa29cf5326b3bfabe65f1c0cc9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information