### PR TITLE
[PLA-2017] Fix total count cache key

### DIFF
--- a/src/CoreServiceProvider.php
+++ b/src/CoreServiceProvider.php
@@ -108,9 +108,9 @@ class CoreServiceProvider extends PackageServiceProvider
         Builder::macro('cursorPaginateWithTotal', function ($order, $limit, $cache = true) {
             if ($cache) {
                 $totalCount = (int) Cache::remember(
-                    $this->toSql(),
+                    $this->toRawSql(),
                     6,
-                    fn () => Cache::lock(PlatformCache::PAGINATION->key($this->toSql()))->get(fn () => $this->count())
+                    fn () => Cache::lock(PlatformCache::PAGINATION->key($this->toRawSql()))->get(fn () => $this->count())
                 );
             }
 
@@ -123,9 +123,9 @@ class CoreServiceProvider extends PackageServiceProvider
         Builder::macro('cursorPaginateWithTotalDesc', function ($order, $limit, $cache = true) {
             if ($cache) {
                 $totalCount = (int) Cache::remember(
-                    $this->toSql(),
+                    $this->toRawSql(),
                     6,
-                    fn () => Cache::lock(PlatformCache::PAGINATION->key($this->toSql()))->get(fn () => $this->count())
+                    fn () => Cache::lock(PlatformCache::PAGINATION->key($this->toRawSql()))->get(fn () => $this->count())
                 );
             }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed cache key generation by replacing `toSql()` with `toRawSql()` in the `cursorPaginateWithTotal` and `cursorPaginateWithTotalDesc` methods.
- Ensures that the cache key accurately reflects the raw SQL query, preventing potential caching issues.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CoreServiceProvider.php</strong><dd><code>Fix cache key generation in pagination macros</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/CoreServiceProvider.php

<li>Replaced <code>toSql()</code> with <code>toRawSql()</code> for cache key generation.<br> <li> Updated cache key logic in <code>cursorPaginateWithTotal</code> and <br><code>cursorPaginateWithTotalDesc</code> methods.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/257/files#diff-7239ef674a3243e4c9895004a5f8ad86f9264922f450c554605b3a1c7fe02d62">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information