### PR TITLE
[PLA-2033] Add AuctionData back

### DIFF
--- a/src/Services/Processor/Substrate/Codec/Types/ListingStorage.json
+++ b/src/Services/Processor/Substrate/Codec/Types/ListingStorage.json
@@ -25,6 +25,10 @@
       "Offer": "OfferData"
     }
   },
+  "AuctionData": {
+    "startBlock": "Compact<u32>",
+    "endBlock": "Compact<u32>"
+  },
   "OfferData": {
     "expiration": "Option<u32>"
   },


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a new `AuctionData` type to the `ListingStorage.json` file, which includes `startBlock` and `endBlock` fields.
- Enhanced the `ListingData` enum to incorporate the newly added `AuctionData` type.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ListingStorage.json</strong><dd><code>Add `AuctionData` type and enhance `ListingData` enum</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Codec/Types/ListingStorage.json

<li>Added <code>AuctionData</code> type with <code>startBlock</code> and <code>endBlock</code> fields.<br> <li> Enhanced the <code>ListingData</code> enum to include <code>AuctionData</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/264/files#diff-ef308bd7c2f0e28e57430e3eaec1dcdd9ef5c4f902cc2f4a3b7b2f789c3a6c12">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information