### PR TITLE
[PLA-2023] Sync attribute when creating or updating

### DIFF
--- a/src/Models/Laravel/Attribute.php
+++ b/src/Models/Laravel/Attribute.php
@@ -39,6 +39,23 @@ class Attribute extends BaseModel
      */
     protected $guarded = [];
 
+    public static function boot(): void
+    {
+        parent::boot();
+
+        static::created(function ($model): void {
+            if ($model->key == '0x757269') {
+                SyncMetadata::dispatch($model->id);
+            }
+        });
+
+        static::updated(function ($model): void {
+            if ($model->key == '0x757269') {
+                SyncMetadata::dispatch($model->id);
+            }
+        });
+    }
+
     /**
      * The attribute key as String.
      */
@@ -82,22 +99,5 @@ class Attribute extends BaseModel
     protected static function newFactory(): AttributeFactory
     {
         return AttributeFactory::new();
-    }
-
-    public static function boot(): void
-    {
-        parent::boot();
-
-        static::created(function($model) {
-            if ($model->key == '0x757269') {
-                SyncMetadata::dispatch($model->id);
-            }
-        });
-
-        static::updated(function($model) {
-            if ($model->key == '0x757269') {
-                SyncMetadata::dispatch($model->id);
-            }
-        });
     }
 }

--- a/src/Models/Laravel/Attribute.php
+++ b/src/Models/Laravel/Attribute.php
@@ -3,6 +3,7 @@
 namespace Enjin\Platform\Models\Laravel;
 
 use Enjin\Platform\Database\Factories\AttributeFactory;
+use Enjin\Platform\Jobs\SyncMetadata;
 use Enjin\Platform\Models\BaseModel;
 use Enjin\Platform\Models\Laravel\Traits\Attribute as AttributeMethods;
 use Enjin\Platform\Models\Laravel\Traits\EagerLoadSelectFields;
@@ -81,5 +82,22 @@ class Attribute extends BaseModel
     protected static function newFactory(): AttributeFactory
     {
         return AttributeFactory::new();
+    }
+
+    public static function boot(): void
+    {
+        parent::boot();
+
+        static::created(function($model) {
+            if ($model->key == '0x757269') {
+                SyncMetadata::dispatch($model->id);
+            }
+        });
+
+        static::updated(function($model) {
+            if ($model->key == '0x757269') {
+                SyncMetadata::dispatch($model->id);
+            }
+        });
     }
 }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a `boot` method to the `Attribute` model to automatically dispatch the `SyncMetadata` job when an attribute is created or updated.
- The synchronization is triggered only if the attribute's `key` matches a specific value (`0x757269`).
- This enhancement ensures that metadata is kept in sync with attribute changes, improving data consistency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Attribute.php</strong><dd><code>Implement automatic metadata synchronization on attribute changes</code></dd></summary>
<hr>

src/Models/Laravel/Attribute.php

<li>Added import for <code>SyncMetadata</code> job.<br> <li> Implemented <code>boot</code> method to dispatch <code>SyncMetadata</code> job on model creation <br>and update.<br> <li> Added condition to check <code>key</code> before dispatching the job.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/276/files#diff-fa7b83988f49e20d1240e0dad01a8b2ea527823b902986ec2f5c870ac512d540">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information