### PR TITLE
[PLA-2057] Fix RemoveAccountRuleData codec

### DIFF
--- a/src/Services/Processor/Substrate/Codec/Types/RemoveAccountRuleData.json
+++ b/src/Services/Processor/Substrate/Codec/Types/RemoveAccountRuleData.json
@@ -5,12 +5,5 @@
     "userId": "MultiAddress",
     "ruleSetId": "u32",
     "ruleKind": "DispatchRuleKind"
-  },
-  "RemoveAccountRuleDataV1010": {
-    "callIndex": "(u8, u8)",
-    "tankId": "MultiAddress",
-    "userId": "MultiAddress",
-    "ruleSetId": "u32",
-    "ruleKind": "DispatchRuleKindV1010"
   }
 }


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Removed the `RemoveAccountRuleDataV1010` object from the JSON codec definition.
- Simplified the codec structure by retaining only the `RemoveAccountRuleData` object.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RemoveAccountRuleData.json</strong><dd><code>Simplify RemoveAccountRuleData codec by removing V1010</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Codec/Types/RemoveAccountRuleData.json

<li>Removed the <code>RemoveAccountRuleDataV1010</code> object.<br> <li> Simplified the codec by keeping only <code>RemoveAccountRuleData</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/282/files#diff-046d0930cfb5b19e28f29208578a3a8141517d62c4df0f166a3bf76ed9733552">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information