### PR TITLE
[PLA-2058] Add anyone can infuse

### DIFF
--- a/src/GraphQL/Schemas/Primary/Substrate/Mutations/MutateTokenMutation.php
+++ b/src/GraphQL/Schemas/Primary/Substrate/Mutations/MutateTokenMutation.php
@@ -131,7 +131,7 @@ class MutateTokenMutation extends Mutation implements PlatformBlockchainTransact
             'mutation' => [
                 'behavior' => is_array($behavior) ? ['NoMutation' => null] : ['SomeMutation' => $behavior?->toEncodable()],
                 'listingForbidden' => Arr::get($params, 'listingForbidden'),
-                'anyoneCanInfuse' => Arr::get($params, 'anyoneCanInfuse', false),
+                'anyoneCanInfuse' => Arr::get($params, 'anyoneCanInfuse'),
                 'name' => ($name = Arr::get($params, 'name')) ? HexConverter::stringToHexPrefixed($name) : null,
             ],
         ];

--- a/src/GraphQL/Types/Input/Substrate/TokenMutationInputType.php
+++ b/src/GraphQL/Types/Input/Substrate/TokenMutationInputType.php
@@ -36,6 +36,14 @@ class TokenMutationInputType extends InputType implements PlatformGraphQlType
                 'type' => GraphQL::type('Boolean'),
                 'description' => __('enjin-platform::input_type.token_mutation.field.listingForbidden'),
             ],
+            'anyoneCanInfuse' => [
+                'type' => GraphQL::type('Boolean'),
+                'description' => __('enjin-platform::type.token.field.anyoneCanInfuse'),
+            ],
+            'name' => [
+                'type' => GraphQL::type('String'),
+                'description' => __('enjin-platform::type.token.field.name'),
+            ],
         ];
     }
 }

--- a/tests/Feature/GraphQL/Mutations/MutateTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/MutateTokenTest.php
@@ -224,6 +224,82 @@ class MutateTokenTest extends TestCaseGraphQL
         Event::assertDispatched(TransactionCreated::class);
     }
 
+    public function test_it_can_mutate_a_token_with_anyone_can_infuse(): void
+    {
+        $encodedData = TransactionSerializer::encode($this->method, MutateTokenMutation::getEncodableParams(
+            collectionId: $collectionId = $this->collection->collection_chain_id,
+            tokenId: $this->tokenIdEncoder->encode(),
+            anyoneCanInfuse: $anyoneCanInfuse = fake()->boolean(),
+        ));
+
+        $response = $this->graphql($this->method, [
+            'collectionId' => $collectionId,
+            'tokenId' => $this->tokenIdEncoder->toEncodable(),
+            'mutation' => [
+                'anyoneCanInfuse' => $anyoneCanInfuse,
+            ],
+            'nonce' => $nonce = fake()->numberBetween(),
+        ]);
+
+        $this->assertArraySubset([
+            'method' => $this->method,
+            'state' => TransactionState::PENDING->name,
+            'encodedData' => $encodedData,
+            'signingPayload' => Substrate::getSigningPayload($encodedData, [
+                'nonce' => $nonce,
+                'tip' => '0',
+            ]),
+            'wallet' => null,
+        ], $response);
+
+        $this->assertDatabaseHas('transactions', [
+            'id' => $response['id'],
+            'method' => $this->method,
+            'state' => TransactionState::PENDING->name,
+            'encoded_data' => $encodedData,
+        ]);
+
+        Event::assertDispatched(TransactionCreated::class);
+    }
+
+    public function test_it_can_mutate_a_token_with_name(): void
+    {
+        $encodedData = TransactionSerializer::encode($this->method, MutateTokenMutation::getEncodableParams(
+            collectionId: $collectionId = $this->collection->collection_chain_id,
+            tokenId: $this->tokenIdEncoder->encode(),
+            name: $name = fake()->name(),
+        ));
+
+        $response = $this->graphql($this->method, [
+            'collectionId' => $collectionId,
+            'tokenId' => $this->tokenIdEncoder->toEncodable(),
+            'mutation' => [
+                'name' => $name,
+            ],
+            'nonce' => $nonce = fake()->numberBetween(),
+        ]);
+
+        $this->assertArraySubset([
+            'method' => $this->method,
+            'state' => TransactionState::PENDING->name,
+            'encodedData' => $encodedData,
+            'signingPayload' => Substrate::getSigningPayload($encodedData, [
+                'nonce' => $nonce,
+                'tip' => '0',
+            ]),
+            'wallet' => null,
+        ], $response);
+
+        $this->assertDatabaseHas('transactions', [
+            'id' => $response['id'],
+            'method' => $this->method,
+            'state' => TransactionState::PENDING->name,
+            'encoded_data' => $encodedData,
+        ]);
+
+        Event::assertDispatched(TransactionCreated::class);
+    }
+
     public function test_it_can_mutate_a_token_with_ss58_signing_account(): void
     {
         $encodedData = TransactionSerializer::encode($this->method, MutateTokenMutation::getEncodableParams(

--- a/tests/Feature/GraphQL/Mutations/MutateTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/MutateTokenTest.php
@@ -679,7 +679,7 @@ class MutateTokenTest extends TestCaseGraphQL
         ], true);
 
         $this->assertArraySubset(
-            ['mutation.behavior' => ['The mutation.behavior field is required when mutation.listing forbidden is not present.']],
+            ['mutation.behavior' => ['The mutation.behavior field is required when none of mutation.listing forbidden / mutation.anyone can infuse / mutation.name are present.']],
             $response['error']
         );
 
@@ -697,7 +697,7 @@ class MutateTokenTest extends TestCaseGraphQL
         ], true);
 
         $this->assertArraySubset(
-            ['mutation.behavior' => ['The mutation.behavior field is required when mutation.listing forbidden is not present.']],
+            ['mutation.behavior' => ['The mutation.behavior field is required when none of mutation.listing forbidden / mutation.anyone can infuse / mutation.name are present.']],
             $response['error']
         );
 
@@ -733,7 +733,7 @@ class MutateTokenTest extends TestCaseGraphQL
         ], true);
 
         $this->assertArraySubset(
-            ['mutation.behavior' => ['The mutation.behavior field is required when mutation.listing forbidden is not present.']],
+            ['mutation.behavior' => ['The mutation.behavior field is required when none of mutation.listing forbidden / mutation.anyone can infuse / mutation.name are present.']],
             $response['error']
         );
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `anyoneCanInfuse` and `name` parameters to the `MutateTokenMutation` class, allowing for more flexible token mutations.
- Updated the mutation encoding logic to handle the new parameters, including converting `name` to a hex string.
- Enhanced validation rules to ensure the presence of at least one of the new or existing parameters.
- Extended the `TokenMutationInputType` to include `anyoneCanInfuse` and `name` fields.
- Implemented new tests to verify the functionality of the `anyoneCanInfuse` and `name` parameters, ensuring they are correctly processed and validated.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MutateTokenMutation.php</strong><dd><code>Add new mutation parameters and update encoding logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Schemas/Primary/Substrate/Mutations/MutateTokenMutation.php

<li>Added <code>anyoneCanInfuse</code> and <code>name</code> parameters to mutation encoding.<br> <li> Updated validation rules to include new parameters.<br> <li> Utilized <code>HexConverter</code> for encoding <code>name</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/283/files#diff-d926c10342e7c4733b902f8b5182fd38be14372a472b97a4a7a963168decf342">+10/-5</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>TokenMutationInputType.php</strong><dd><code>Extend input type with new fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Types/Input/Substrate/TokenMutationInputType.php

- Introduced `anyoneCanInfuse` and `name` fields to the input type.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/283/files#diff-e1cc06446e4bec83a0e7f9758f827fad4f0f91b1bcbe6a7ab5805f397882aaa2">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MutateTokenTest.php</strong><dd><code>Add tests for new mutation parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/MutateTokenTest.php

<li>Added tests for <code>anyoneCanInfuse</code> and <code>name</code> mutation parameters.<br> <li> Updated existing tests to reflect new validation rules.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/283/files#diff-d9ff4b8cd9024eb4a466b15f735ca42749012fda248d94ce9045a9cb90cc56a8">+79/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information