### PR TITLE
[PLA-2088] Fix collapsing supply

### DIFF
--- a/src/Services/Blockchain/Implementations/Substrate.php
+++ b/src/Services/Blockchain/Implementations/Substrate.php
@@ -242,7 +242,7 @@ class Substrate implements BlockchainServiceInterface
         $cap = Arr::get($args, 'cap.type');
 
         // TODO: SingleMint can be removed on v2.1.0
-        if ($cap === 'SINGLE_MINT' || $cap === 'COLLAPSING_SUPPLY') {
+        if ($cap === 'SINGLE_MINT') {
             $data['cap'] = TokenMintCapType::COLLAPSING_SUPPLY;
             $data['capSupply'] = $args['initialSupply'];
         }

--- a/src/Services/Processor/Substrate/Events/Implementations/MultiTokens/TokenCreated.php
+++ b/src/Services/Processor/Substrate/Events/Implementations/MultiTokens/TokenCreated.php
@@ -49,7 +49,6 @@ class TokenCreated extends SubstrateEvent
 
         $extrinsic = $this->block->extrinsics[$this->event->extrinsicIndex];
         $params = $extrinsic->params;
-        Log::info('Create token params', $params);
 
         // This unwraps any calls from a FuelTank extrinsic
         if ($extrinsic->module === 'FuelTanks') {

--- a/src/Services/Processor/Substrate/Events/Implementations/MultiTokens/TokenCreated.php
+++ b/src/Services/Processor/Substrate/Events/Implementations/MultiTokens/TokenCreated.php
@@ -49,6 +49,7 @@ class TokenCreated extends SubstrateEvent
 
         $extrinsic = $this->block->extrinsics[$this->event->extrinsicIndex];
         $params = $extrinsic->params;
+        Log::info('Create token params', $params);
 
         // This unwraps any calls from a FuelTank extrinsic
         if ($extrinsic->module === 'FuelTanks') {

--- a/tests/Feature/GraphQL/Mutations/CreateTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateTokenTest.php
@@ -358,7 +358,7 @@ class CreateTokenTest extends TestCaseGraphQL
         Event::assertDispatched(TransactionCreated::class);
     }
 
-    public function test_can_create_a_token_with_collapsin_g_supply(): void
+    public function test_can_create_a_token_with_collapsing_supply(): void
     {
         $encodedData = TransactionSerializer::encode('Mint', CreateTokenMutation::getEncodableParams(
             recipientAccount: $recipient = $this->recipient->public_key,
@@ -367,6 +367,7 @@ class CreateTokenTest extends TestCaseGraphQL
                 tokenId: $this->tokenIdEncoder->encode($tokenId = fake()->numberBetween()),
                 initialSupply: $initialSupply = fake()->numberBetween(1),
                 cap: $capType = TokenMintCapType::COLLAPSING_SUPPLY,
+                capSupply: $initialSupply + 10
             ),
         ));
 
@@ -378,6 +379,7 @@ class CreateTokenTest extends TestCaseGraphQL
                 'initialSupply' => $initialSupply,
                 'cap' => [
                     'type' => $capType->name,
+                    'amount' => $initialSupply + 10,
                 ],
             ],
         ]);


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed the logic for setting the token mint cap type by removing the incorrect condition for 'COLLAPSING_SUPPLY'.
- Ensured that the cap type is correctly set only when 'SINGLE_MINT' is specified.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Substrate.php</strong><dd><code>Fix condition for setting token mint cap type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Blockchain/Implementations/Substrate.php

<li>Removed the condition checking for 'COLLAPSING_SUPPLY' in the if <br>statement.<br> <li> Ensured that only 'SINGLE_MINT' is checked for setting the cap type.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/288/files#diff-c31502aa2f1476099673a2f9744b629d87d0c00ecf3c56e3269804cadc59b3ed">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information