### PR TITLE
[PLA-1946] Fix translation

### DIFF
--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -40,5 +40,5 @@ return [
     'string_too_large' => 'The :attribute field is too large.',
     'not_daemon_wallet' => 'The :attribute is a daemon wallet and should not be used as a signingAccount.',
     'keep_existential_deposit' => 'The :attribute is not enough to keep the existential deposit of :existentialDeposit.',
-    'invalid_after' => 'The :attribute contains and invalid encoded data.',
+    'invalid_after' => 'The :attribute contains an invalid encoded data.',
 ];


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a typo in the 'invalid_after' translation string in the English validation file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validation.php</strong><dd><code>Fix typo in 'invalid_after' translation string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lang/en/validation.php

- Corrected a typo in the translation string for 'invalid_after'.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/290/files#diff-31a31d40d62ce50b5e434f851645fcfd67a47eb50238e32468433a863a737182">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information