### PR TITLE
[PLA-1931] Fixes signature encoding

### DIFF
--- a/src/Services/Processor/Substrate/Codec/Types/Dispatch.json
+++ b/src/Services/Processor/Substrate/Codec/Types/Dispatch.json
@@ -13,7 +13,7 @@
     "signature": "Option<ExpirableSignature>"
   },
   "ExpirableSignature": {
-    "signature": "[u8; 32]",
+    "signature": "H512",
     "expiryBlock": "u32"
   }
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the type of `signature` in the `ExpirableSignature` structure from `[u8; 32]` to `H512` in the `Dispatch.json` file.
- This resolves potential issues with signature encoding and ensures compatibility with expected formats.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dispatch.json</strong><dd><code>Fix signature type in `ExpirableSignature` definition</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Codec/Types/Dispatch.json

<li>Changed the type of <code>signature</code> in <code>ExpirableSignature</code> from <code>[u8; 32]</code> to <br><code>H512</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/300/files#diff-3212a709d557a205b88ad333ea7e9625a42f9fb2bfda8d8dbb00634384903d8e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information