### PR TITLE
[PLA-2115] Keep enough value to pay for teleporting fee

### DIFF
--- a/src/Commands/RelayWatcher.php
+++ b/src/Commands/RelayWatcher.php
@@ -235,7 +235,7 @@ class RelayWatcher extends Command
         ]);
 
         $transferableAmount = $this->codec->encoder()->compact(
-            gmp_strval(gmp_sub($amount, '100000000000000000'))
+            gmp_strval(gmp_sub($amount, '101000000000000000'))
         );
         $call = '0x630903000100a10f0300010100' . HexConverter::unPrefix($managedWallet->public_key);
         $call .= '030400000000' . HexConverter::unPrefix($transferableAmount);


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Adjusted the fee calculation in the `createDaemonTransaction` method to subtract a slightly higher value (`101000000000000000` instead of `100000000000000000`).
- Ensures that enough value is retained to cover teleporting fees, addressing potential underpayment issues.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RelayWatcher.php</strong><dd><code>Adjust fee calculation to ensure sufficient teleporting value</code></dd></summary>
<hr>

src/Commands/RelayWatcher.php

<li>Adjusted the fee calculation by increasing the subtracted value from <br><code>100000000000000000</code> to <code>101000000000000000</code>.<br> <li> Ensures sufficient value is retained to cover teleporting fees.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/301/files#diff-48110bb63d25893338956f8dcdb6ba722c4671edff58ddeedcbae42d6552e617">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information