### PR TITLE
[PLA-2115] Keep enough value to pay for teleporting fee

### DIFF
--- a/src/Commands/RelayWatcher.php
+++ b/src/Commands/RelayWatcher.php
@@ -235,7 +235,7 @@ class RelayWatcher extends Command
         ]);
 
         $transferableAmount = $this->codec->encoder()->compact(
-            gmp_strval(gmp_sub($amount, '101000000000000000'))
+            gmp_strval(gmp_sub($amount, '201000000000000000'))
         );
         $call = '0x630903000100a10f0300010100' . HexConverter::unPrefix($managedWallet->public_key);
         $call .= '030400000000' . HexConverter::unPrefix($transferableAmount);


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed an issue in the `createDaemonTransaction` method where the teleport fee buffer was insufficient.
- Increased the buffer value to ensure enough funds are retained for teleporting fees.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RelayWatcher.php</strong><dd><code>Adjust teleport fee buffer in transaction creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Commands/RelayWatcher.php

<li>Adjusted the subtraction value in the <code>createDaemonTransaction</code> method.<br> <li> Increased the teleport fee buffer from <code>101000000000000000</code> to <br><code>201000000000000000</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/302/files#diff-48110bb63d25893338956f8dcdb6ba722c4671edff58ddeedcbae42d6552e617">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information