### PR TITLE
[PLA-2145] Check the correct attribute for is_currency

### DIFF
--- a/src/Commands/Sync.php
+++ b/src/Commands/Sync.php
@@ -120,7 +120,7 @@ class Sync extends Command
         foreach ($storages as $storage) {
             $this->info(sprintf(
                 '%s: %s',
-                ucwords(str_replace('_', ' ', strtolower($storage[0]->type->name))),
+                ucwords(str_replace('_', ' ', strtolower((string) $storage[0]->type->name))),
                 $storage[2]
             ));
         }

--- a/src/GraphQL/Types/Scalars/DateTimeType.php
+++ b/src/GraphQL/Types/Scalars/DateTimeType.php
@@ -40,7 +40,7 @@ class DateTimeType extends ScalarType implements PlatformGraphQlType, TypeConver
      */
     public function parseLiteral($valueNode, ?array $variables = null)
     {
-        if (!strtotime($valueNode->value)) {
+        if (!strtotime((string) $valueNode->value)) {
             throw new Error(__('enjin-platform::error.invalid_datetime'), [$valueNode]);
         }
 

--- a/src/Services/Processor/Substrate/Codec/Polkadart/Events/MultiTokens/TokenMutated.php
+++ b/src/Services/Processor/Substrate/Codec/Polkadart/Events/MultiTokens/TokenMutated.php
@@ -35,7 +35,7 @@ class TokenMutated extends Event implements PolkadartEvent
         $self->tokenId = $self->getValue($data, 'T::TokenId');
         $self->listingForbidden = $self->getValue($data, 'T::TokenMutation.listing_forbidden.SomeMutation');
         $self->behavior = is_string($behavior = $self->getValue($data, 'T::TokenMutation.behavior')) ? $behavior : array_key_first($behavior);
-        $self->isCurrency = $self->getValue($data, 'T::TokenMutation.behavior.SomeMutation.Some') === 'IsCurrency';
+        $self->isCurrency = $self->getValue($data, 'T::TokenMutation.behavior.SomeMutation') === ['IsCurrency' => null];
         $self->beneficiary = Account::parseAccount($self->getValue($data, 'T::TokenMutation.behavior.SomeMutation.HasRoyalty.beneficiary'));
         $self->percentage = $self->getValue($data, 'T::TokenMutation.behavior.SomeMutation.HasRoyalty.percentage');
         $self->anyoneCanInfuse = $self->getValue($data, 'T::TokenMutation.anyone_can_infuse.SomeMutation');


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the condition for checking `isCurrency` attribute.

- Updated logic to correctly compare `isCurrency` value.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TokenMutated.php</strong><dd><code>Fix `isCurrency` attribute condition logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Codec/Polkadart/Events/MultiTokens/TokenMutated.php

<li>Updated the condition for <code>isCurrency</code> attribute.<br> <li> Changed comparison logic to match expected structure.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/317/files#diff-714b6f75ac7534170fca96927b2332ae1ac16f66104fa1350e088aa610d7ed90">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information