### PR TITLE
[PLA-2151] Fixes relay watcher

### DIFF
--- a/config/enjin-platform.php
+++ b/config/enjin-platform.php
@@ -109,7 +109,7 @@ return [
                     'network-id' => 2010,
                     'testnet' => true,
                     'platform-id' => env('SUBSTRATE_CANARY_PLATFORM_ID', 0),
-                    'node' => env('SUBSTRATE_CANARY_RPC', 'wss://archive.matrix.canary.enjin.io'),
+                    'node' => env('SUBSTRATE_CANARY_RPC', 'wss://rpc.matrix.canary.enjin.io'),
                     'ss58-prefix' => env('SUBSTRATE_CANARY_SS58_PREFIX', 9030),
                     'genesis-hash' => env('SUBSTRATE_CANARY_GENESIS_HASH', '0xa37725fd8943d2a524cb7ecc65da438f9fa644db78ba24dcd0003e2f95645e8f'),
                 ],

--- a/src/Commands/Sync.php
+++ b/src/Commands/Sync.php
@@ -120,7 +120,7 @@ class Sync extends Command
         foreach ($storages as $storage) {
             $this->info(sprintf(
                 '%s: %s',
-                ucwords(str_replace('_', ' ', strtolower($storage[0]->type->name))),
+                ucwords(str_replace('_', ' ', strtolower((string) $storage[0]->type->name))),
                 $storage[2]
             ));
         }

--- a/src/GraphQL/Types/Scalars/DateTimeType.php
+++ b/src/GraphQL/Types/Scalars/DateTimeType.php
@@ -40,7 +40,7 @@ class DateTimeType extends ScalarType implements PlatformGraphQlType, TypeConver
      */
     public function parseLiteral($valueNode, ?array $variables = null)
     {
-        if (!strtotime($valueNode->value)) {
+        if (!strtotime((string) $valueNode->value)) {
             throw new Error(__('enjin-platform::error.invalid_datetime'), [$valueNode]);
         }
 

--- a/src/Services/Blockchain/Implementations/Substrate.php
+++ b/src/Services/Blockchain/Implementations/Substrate.php
@@ -131,8 +131,8 @@ class Substrate implements BlockchainServiceInterface
             nonce: Arr::get($args, 'nonce'),
             blockHash: networkConfig('genesis-hash'),
             genesisHash: networkConfig('genesis-hash'),
-            specVersion: cachedRuntimeConfig(PlatformCache::SPEC_VERSION),
-            txVersion: cachedRuntimeConfig(PlatformCache::TRANSACTION_VERSION),
+            specVersion: cachedRuntimeConfig(PlatformCache::SPEC_VERSION, currentMatrix()),
+            txVersion: cachedRuntimeConfig(PlatformCache::TRANSACTION_VERSION, currentMatrix()),
             tip: Arr::get($args, 'tip'),
         );
     }
@@ -148,8 +148,8 @@ class Substrate implements BlockchainServiceInterface
             nonce: Arr::get($args, 'nonce'),
             blockHash: networkConfig('genesis-hash'),
             genesisHash: networkConfig('genesis-hash'),
-            specVersion: cachedRuntimeConfig(PlatformCache::SPEC_VERSION),
-            txVersion: cachedRuntimeConfig(PlatformCache::TRANSACTION_VERSION),
+            specVersion: cachedRuntimeConfig(PlatformCache::SPEC_VERSION, currentMatrix()),
+            txVersion: cachedRuntimeConfig(PlatformCache::TRANSACTION_VERSION, currentMatrix()),
             tip: Arr::get($args, 'tip'),
         );
     }

--- a/src/Services/Processor/Substrate/BlockProcessor.php
+++ b/src/Services/Processor/Substrate/BlockProcessor.php
@@ -156,8 +156,8 @@ class BlockProcessor
         $this->info('Connected to: ' . currentMatrix()->value);
         $this->info("Current block on-chain: {$lastBlock}");
         $this->info("Continuing from block: {$lastSyncedHeight}");
-        $this->info("Transaction version: {$runtime[PlatformCache::TRANSACTION_VERSION->key()]}");
-        $this->info("Spec version: {$runtime[PlatformCache::SPEC_VERSION->key()]}");
+        $this->info("Transaction version: {$runtime[0]}");
+        $this->info("Spec version: {$runtime[1]}");
         $this->info('=========================================================');
 
         $this->startIngest($lastSyncedHeight, $lastBlock);

--- a/src/Services/Processor/Substrate/Events/Implementations/System/CodeUpdated.php
+++ b/src/Services/Processor/Substrate/Events/Implementations/System/CodeUpdated.php
@@ -17,8 +17,8 @@ class CodeUpdated extends SubstrateEvent
 
     public function run(): void
     {
-        Cache::forget(PlatformCache::SPEC_VERSION->key());
-        Cache::forget(PlatformCache::TRANSACTION_VERSION->key());
+        Cache::forget(PlatformCache::SPEC_VERSION->key(currentMatrix()->value));
+        Cache::forget(PlatformCache::TRANSACTION_VERSION->key(currentMatrix()->value));
     }
 
     public function log(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,8 +31,8 @@ abstract class TestCase extends BaseTestCase
         $app->useDatabasePath(__DIR__ . '/../database');
         $app->bootstrapWith([LoadEnvironmentVariables::class]);
 
-        Cache::rememberForever(PlatformCache::SPEC_VERSION->key(), fn () => 1023);
-        Cache::rememberForever(PlatformCache::TRANSACTION_VERSION->key(), fn () => 10);
+        Cache::rememberForever(PlatformCache::SPEC_VERSION->key(currentMatrix()->value), fn () => 1023);
+        Cache::rememberForever(PlatformCache::TRANSACTION_VERSION->key(currentMatrix()->value), fn () => 10);
 
         $app['config']->set('database.default', env('DB_DRIVER', 'mysql'));
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed incorrect RPC URL for Canary network in configuration.

- Enhanced logging in `RelayWatcher` for better runtime insights.

- Updated `Util::updateRuntimeVersion` to support network-specific caching.

- Added helper functions for network-specific URL and configuration handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>enjin-platform.php</strong><dd><code>Fix incorrect Canary network RPC URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/enjin-platform.php

- Corrected the RPC URL for the Canary network.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/319/files#diff-e687a9c8af991f77587526ea6983e8c280929f8ccf6b989eb1eb83c0d8f4d220">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RelayWatcher.php</strong><dd><code>Enhance logging and runtime handling in RelayWatcher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Commands/RelayWatcher.php

<li>Added runtime version logging during relay ingestion.<br> <li> Improved subscription logging for better clarity.<br> <li> Fixed time difference calculation for block ingestion.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/319/files#diff-48110bb63d25893338956f8dcdb6ba722c4671edff58ddeedcbae42d6552e617">+12/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BlockProcessor.php</strong><dd><code>Update runtime logging in BlockProcessor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/BlockProcessor.php

- Adjusted runtime version logging to use updated method.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/319/files#diff-5e9d1640ff87e611a83e41e14038785fc69b77343a16a046571f964b5f3db954">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Util.php</strong><dd><code>Add network-specific caching in Util</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Support/Util.php

<li>Modified <code>updateRuntimeVersion</code> to support network-specific caching.<br> <li> Adjusted caching keys to include network context.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/319/files#diff-5367c403435b44663d1784b281980f13a7115d9c398633a348b4bf286e9c4bf1">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>helpers.php</strong><dd><code>Add and enhance network-specific helper functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Support/helpers.php

<li>Added <code>networkUrl</code> helper for network-specific URLs.<br> <li> Enhanced <code>isMatrix</code> and <code>isRelay</code> to handle null network.<br> <li> Updated <code>cachedRuntimeConfig</code> to support network-specific caching.<br> <li> Improved <code>specForBlock</code> to use updated caching logic.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-core/pull/319/files#diff-3e5775295c528f7b783a114f48e742f114e2d57204570c904c4b304b62f16754">+27/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>